### PR TITLE
make sample code "skinny" to 70 cols

### DIFF
--- a/src/sample/CreateAndEndorseAccessTokenSample.js
+++ b/src/sample/CreateAndEndorseAccessTokenSample.js
@@ -7,7 +7,9 @@
  */
 export default async (grantor, granteeAlias) => {
     // Grantor creates the token with the desired terms
-    const token = await grantor.createAccessToken(granteeAlias, [{allAccounts: {}}]);
+    const token = await grantor.createAccessToken(
+        granteeAlias,
+        [{allAccounts: {}}]);
 
     // Grantor endorses the token, creating and submitting a digital signature
     const result = await grantor.endorseToken(token);

--- a/src/sample/CreateTransferTokenAttachSample.js
+++ b/src/sample/CreateTransferTokenAttachSample.js
@@ -18,7 +18,8 @@ export default async (payer, payeeAlias) => {
     const token = await payer.createTransferToken(100.00, 'EUR')
           .setAccountId(accounts[0].id)
           .setRedeemerAlias(payeeAlias)
-          .addAttachment(attachment)    // attach reference to token
+          // attach reference to token:
+          .addAttachment(attachment)
           .execute();
 
     const result = await payer.endorseToken(token);

--- a/src/sample/GetTransactionSample.js
+++ b/src/sample/GetTransactionSample.js
@@ -10,7 +10,9 @@ export default async (payer, transfer) => {
     const accountId = accounts[0].id;
 
     const transactionId = transfer.transactionId;
-    const transaction = await payer.getTransaction(accountId, transactionId);
+    const transaction = await payer.getTransaction(
+        accountId,
+        transactionId);
 
     return transaction;
 };

--- a/src/sample/GetTransactionsSample.js
+++ b/src/sample/GetTransactionsSample.js
@@ -8,7 +8,10 @@ export default async (payer) => {
     const accounts = await payer.getAccounts();
     const accountId = accounts[0].id;
 
-    const pagedResult = await payer.getTransactions(accountId, "", 10);
+    const pagedResult = await payer.getTransactions(
+        accountId,
+        "",
+        10);
     return pagedResult.data;
 };
 

--- a/src/sample/GetTransferTokenAttachmentsSample.js
+++ b/src/sample/GetTransferTokenAttachmentsSample.js
@@ -13,9 +13,10 @@ export default async (payee, tokenId) => {
 
     var allContents = [];
 
-    for (var ix = 0; ix < transferToken.payload.transfer.attachments.length; ix++) {
+    const transferBody = transferToken.payload.transfer;
+    for (var ix = 0; ix < transferBody.attachments.length; ix++) {
         // attachments have metadata but not the "file" content
-        const att = transferToken.payload.transfer.attachments[ix];
+        const att = transferBody.attachments[ix];
         // download the content of the attachment[s] we want
         const blob = await payee.getTokenBlob(tokenId, att.blobId);
         const blobContents = base64js.toByteArray(blob.payload.data);

--- a/src/sample/LinkMemberAndBankSample.js
+++ b/src/sample/LinkMemberAndBankSample.js
@@ -11,9 +11,10 @@
  * @param {Member} member - Token member to link to a bank
  */
 export default async (member) => {
-    // Generates a test bank account that we can link with
-    const encryptedBankAuthorization = await member.createTestBankAccount(200, 'EUR');
+    // Generates a test bank account that we can link with.
+    // Gives us an encrypted BankAuthorization
+    const auth = await member.createTestBankAccount(200, 'EUR');
 
-    // Links the account, by sending the bank authorization
-    const accounts = await member.linkAccounts(encryptedBankAuthorization);
+    // Links the account by sending the BankAuthorization
+    const accounts = await member.linkAccounts(auth);
 };

--- a/src/sample/MemberGetBalanceSample.js
+++ b/src/sample/MemberGetBalanceSample.js
@@ -10,7 +10,8 @@ export default async (member) => {
     for (var i = 0; i < accounts.length; i++) {
         const balance = await member.getBalance(accounts[i].id);
         const currency = balance.available.currency;
-        sums[currency] = (sums[currency] || 0) + parseFloat(balance.available.value);
+        sums[currency] = (sums[currency] || 0) +
+            parseFloat(balance.available.value);
     }
     return sums;
 };

--- a/src/sample/RedeemAccessTokenSample.js
+++ b/src/sample/RedeemAccessTokenSample.js
@@ -7,7 +7,8 @@
  * @return {Array} accounts - grantor accounts
  */
 export default async (grantee, tokenId) => {
-    // Use the access token, now making API calls on behalf of the grantor, and get accounts
+    // Use the access token, now making API calls
+    // on behalf of the grantor, and get accounts
     grantee.useAccessToken(tokenId);
     const accounts = await grantee.getAccounts();
 

--- a/src/sample/RedeemTransferTokenSample.js
+++ b/src/sample/RedeemTransferTokenSample.js
@@ -19,7 +19,12 @@ export default async (payee, tokenId) => {
     };
 
     // Payer redeems the token, getting a transfer
-    const transfer = await payee.redeemToken(transferToken, 5, 'EUR', 'lunch', [destination]);
+    const transfer = await payee.redeemToken(
+        transferToken,
+        5,
+        'EUR',
+        'lunch',
+        [destination]);
 
     return transfer;
 };

--- a/src/sample/ReplaceAccessTokenSample.js
+++ b/src/sample/ReplaceAccessTokenSample.js
@@ -6,7 +6,10 @@
  * @return {Object} result - new token
  */
 export default async (grantor, oldToken) => {
-    const replaceResult = await grantor.replaceAccessToken(oldToken, [{allTransactions: {}}]);
-    const endorseResult = await grantor.endorseToken(replaceResult.token);
+    const replaceResult = await grantor.replaceAccessToken(
+        oldToken,
+        [{allTransactions: {}}]);
+    const endorseResult = await grantor.endorseToken(
+        replaceResult.token);
     return endorseResult.token;
 };


### PR DESCRIPTION
When we auto-copy sample code into the docs,
if it's too wide then the reader can't see
everything and horizontal scroll bars clutter things up.