### PR TITLE
refId: add param in redeemToken. use in samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-io",
-  "version": "1.4.89",
+  "version": "1.4.90",
   "description": "",
   "main": "dist/token-io.min.js",
   "scripts": {

--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -720,11 +720,15 @@ class AuthHttpClient {
      * @param {string} currency - currency to charge
      * @param {string} description - description of the transfer
      * @param {Array} destinations - destinations money should go to
+     * @param {string} refId - reference Id to attach to the transfer
      * @return {Object} response - response to the API call
      */
-    async redeemToken(transferToken, amount, currency, description, destinations) {
+    async redeemToken(transferToken, amount, currency, description, destinations, refId) {
+        if (!refId) {
+            refId = Util.generateNonce();
+        }
         const payload = {
-            refId: Util.generateNonce(),
+            refId: refId,
             tokenId: transferToken.id,
             amount: {
                 value: amount.toString(),

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -624,9 +624,13 @@ export default class Member {
      * @param {string} currency - currency to redeem
      * @param {string} description - optional transfer description
      * @param {Array} destinations - transfer destinations
+     * @param {string} refId - Id that will be set on created Transfer.
+     *                         Token uses this to detect duplicates.
+     *                         Caller might use this to recognize the transfer.
+     *                         If param empty, transfer will have random refId.
      * @return {Promise} transfer - Transfer created as a result of this redeem call
      */
-    redeemToken(token, amount, currency, description, destinations = []) {
+    redeemToken(token, amount, currency, description, destinations = [], refId = null) {
         return Util.callAsync(this.redeemToken, async () => {
             const finalToken = await this._resolveToken(token);
             if (amount === undefined) {
@@ -644,7 +648,8 @@ export default class Member {
                 amount,
                 currency,
                 description,
-                destinations);
+                destinations,
+                refId);
             return res.data.transfer;
         });
     }

--- a/src/main/TransferTokenBuilder.js
+++ b/src/main/TransferTokenBuilder.js
@@ -106,7 +106,8 @@ export default class TransferTokenBuilder {
      */
     setChargeAmount(chargeAmount) {
         if (Util.countDecimals(chargeAmount) > config.decimalPrecision) {
-            throw new Error(`Number of decimals in amount should be at most ${config.decimalPrecision}`);
+            throw new Error('Number of decimals in amount should be at most ' +
+                            config.decimalPrecision);
         }
         this._payload.transfer.amount = chargeAmount;
         return this;

--- a/src/sample/CreateAndEndorseTransferTokenSample.js
+++ b/src/sample/CreateAndEndorseTransferTokenSample.js
@@ -1,3 +1,5 @@
+import Util from "../Util";
+
 /**
  * Creates a transfer token and endorses it to a payee.
  *
@@ -6,13 +8,21 @@
  * @return {Object} token - endorsed token
  */
 export default async (payer, payeeAlias) => {
+    // We'll use this as a reference ID. Normally, a payer who
+    // explicitly sets a reference ID would use an ID from a db.
+    // E.g., a bill-paying service might use ID of a "purchase".
+    // We don't have a db, so we fake it with a random string:
+    const purchaseId = Util.generateNonce();
+
     const accounts = await payer.getAccounts();
 
     // Payer creates the token with the desired terms
     const token = await payer.createTransferToken(100.00, 'EUR')
-            .setAccountId(accounts[0].id)
-            .setRedeemerAlias(payeeAlias)
-            .execute();
+          .setAccountId(accounts[0].id)
+          .setRedeemerAlias(payeeAlias)
+          // if not explicitly set, will get random refId:
+          .setRefId(purchaseId)
+          .execute();
 
     // Payer endorses the token, creating a digital signature on it
     const result = await payer.endorseToken(token);

--- a/src/sample/NotifyPaymentRequestSample.js
+++ b/src/sample/NotifyPaymentRequestSample.js
@@ -1,3 +1,5 @@
+import Util from "../Util";
+
 /**
  * Send a payment request (TokenPayload) to a potential-payer.
  *
@@ -7,6 +9,12 @@
  * @return {Object} NotifyStatus - status
  */
 export default async (Token, payee, payerAlias) => {
+    // We'll use this as a reference ID. Normally, a payee who
+    // explicitly sets a reference ID would use an ID from a db.
+    // E.g., an online merchant might use the ID of a "shopping cart".
+    // We don't have a db, so we fake it with a random string:
+    const cartId = Util.generateNonce();
+
     const payeeAlias = {
         type: 'USERNAME',
         value: await payee.firstAlias()
@@ -25,7 +33,10 @@ export default async (Token, payee, payerAlias) => {
         transfer: {
             amount: '100',
             currency: 'EUR'
-        }
+        },
+        // if refID not set, the eventually-created
+        // transfer token will have random refId:
+        refId: cartId,
     };
     const status = await Token.notifyPaymentRequest(
         payerAlias,

--- a/src/sample/RedeemTransferTokenSample.js
+++ b/src/sample/RedeemTransferTokenSample.js
@@ -1,3 +1,5 @@
+import Util from "../Util";
+
 /**
  * Redeems a transfer token.
  *
@@ -6,6 +8,12 @@
  * @return {Object} transfer - created transfer
  */
 export default async (payee, tokenId) => {
+    // We'll use this as a reference ID. Normally, a payee who
+    // explicitly sets a reference ID would use an ID from a db.
+    // E.g., an online merchant might use the ID of a "shopping cart".
+    // We don't have a db, so we fake it with a random string:
+    const cartId = Util.generateNonce();
+
     // Payee gets the token to see details
     const transferToken = await payee.getToken(tokenId);
 
@@ -24,7 +32,8 @@ export default async (payee, tokenId) => {
         5,
         'EUR',
         'lunch',
-        [destination]);
+        [destination],
+        cartId);
 
     return transfer;
 };

--- a/test/main/Redemptions.spec.js
+++ b/test/main/Redemptions.spec.js
@@ -53,10 +53,12 @@ describe('Token Redemptions', async () => {
     beforeEach(setUp3);
 
     it('should redeem a basic token', async () => {
-        const transfer = await member2.redeemToken(token1, 10.21, 'EUR', '', [destination1]);
+        const refId = Token.Util.generateNonce();
+        const transfer = await member2.redeemToken(token1, 10.21, 'EUR', '', [destination1], refId);
         assert.equal(10.21, transfer.payload.amount.value);
         assert.equal('EUR', transfer.payload.amount.currency);
         assert.isAtLeast(transfer.payloadSignatures.length, 1);
+        assert.equal(refId, transfer.payload.refId);
     });
 
     it('should create and redeem a token with destination', async () => {
@@ -86,6 +88,7 @@ describe('Token Redemptions', async () => {
         assert.equal(15.28, transfer.payload.amount.value);
         assert.equal('EUR', transfer.payload.amount.currency);
         assert.isAtLeast(transfer.payloadSignatures.length, 1);
+        assert.isAtLeast(transfer.payload.refId.length, 1);
         const bal = await member1.getBalance(account1.id);
         assert.isAtLeast(100000, bal.current.value);
     });


### PR DESCRIPTION
explicitly set refId in create-token and redeem-token samples
so we have an excuse to talk about it in docs

JS redeemToken didn't take a refId param, always used nonce.
Added the param to match Java redeemToken