### PR TITLE
Member.firstAlias return an alias not a string

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,12 +1,21 @@
-## Release 1.4.94
+## Release 1.4.95
+
+### Member.firstAlias
+
+Member.firstAlias' return type changed from a string (like
+"address@example.com") to alias structure (like
+{ type: "EMAIL", value: "address@example.com" } ).
 
 ### Iframe
 
-The JS SDK now uses an iframe to the Token API server, when being called under a token domain. This removes the preflight request, and speeds up the experience.
+The JS SDK now uses an iframe to the Token API server, when being called
+under a token domain. This removes the preflight request, and speeds up
+the experience.
 
 ## Release 1.4.91
 
 ### notifyPaymentRequest
 
-There has been a change to the parameters for the method notifyPaymentRequest. The Alias parameter has been removed,
-the method now receives a single parameter, the TokenPayload.
+There has been a change to the parameters for the method notifyPaymentRequest.
+The Alias parameter has been removed, the method now receives a single
+parameter, the TokenPayload.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-io",
-  "version": "1.4.94",
+  "version": "1.4.95",
   "description": "",
   "main": "dist/token-io.min.js",
   "scripts": {

--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -989,6 +989,21 @@ class AuthHttpClient {
     }
 
     /**
+     * Gets logged-in member's aliases, verified or not.
+     *
+     * @return {Object} response object; has aliases, unverifiedAliases
+     */
+    async getAliases() {
+        const req = {};
+        const request = {
+            method: 'get',
+            url: '/aliases',
+            data: req,
+        };
+        return this._instance(request);
+    }
+
+    /**
      * Adds aliases to the member.
      *
      * @param {string} prevHash - hash of the previous directory entry.

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -56,8 +56,8 @@ export default class Member {
      */
     firstAlias() {
         return Util.callAsync(this.firstAlias, async () => {
-            const member = await this._getMember();
-            return member.aliasHashes[0];
+            const res = await this._client.getAliases();
+            return res.data.aliases[0];
         });
     }
 

--- a/src/sample/NotifyPaymentRequestSample.js
+++ b/src/sample/NotifyPaymentRequestSample.js
@@ -15,10 +15,7 @@ export default async (Token, payee, payerAlias) => {
     // We don't have a db, so we fake it with a random string:
     const cartId = Util.generateNonce();
 
-    const payeeAlias = {
-        type: 'USERNAME',
-        value: await payee.firstAlias()
-    };
+    const payeeAlias = await payee.firstAlias();
 
     // Payment request is a TokenPayload
     // protocol buffer.

--- a/test/sample/CancelAccessTokenSample.spec.js
+++ b/test/sample/CancelAccessTokenSample.spec.js
@@ -14,7 +14,7 @@ describe('CancelAccessTokenSample test', () => {
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseAccessTokenSample(member, member2Alias);
         const res2 = await CancelAccessTokenSample(member, res.id);
         assert.equal(res2.status, 'SUCCESS');

--- a/test/sample/CancelTransferTokenSample.spec.js
+++ b/test/sample/CancelTransferTokenSample.spec.js
@@ -16,7 +16,7 @@ describe('CancelTransferTokenSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         const res2 = await CancelTransferTokenSample(member, res.id);
         assert.equal(res2.status, 'SUCCESS');

--- a/test/sample/CreateAndEndorseAccessTokenSample.spec.js
+++ b/test/sample/CreateAndEndorseAccessTokenSample.spec.js
@@ -13,7 +13,7 @@ describe('CreateAndEndorseAccessTokenSample test', () => {
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseAccessTokenSample(member, member2Alias);
         assert.isAtLeast(res.payloadSignatures.length, 2);
     });

--- a/test/sample/CreateAndEndorseTransferTokenSample.spec.js
+++ b/test/sample/CreateAndEndorseTransferTokenSample.spec.js
@@ -19,7 +19,7 @@ describe('CreateAndEndorseTransferTokenSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         assert.isAtLeast(res.payloadSignatures.length, 2);
     });
@@ -41,7 +41,7 @@ describe('CreateTransferTokenToDestinationSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/CreateAndEndorseTransferTokenSampleWithAttachment.spec.js
+++ b/test/sample/CreateAndEndorseTransferTokenSampleWithAttachment.spec.js
@@ -17,7 +17,7 @@ describe('CreateAndEndorseTransferTokenWithAttachmentSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res =
             await CreateAndEndorseTransferTokenWithAttachmentSample(member, member2Alias);
         assert.isAtLeast(res.payloadSignatures.length, 2);
@@ -31,7 +31,7 @@ describe('CreateTransferTokenAttachSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res =
             await CreateTransferTokenAttachSample(member, member2Alias);
         assert.isAtLeast(res.payloadSignatures.length, 2);

--- a/test/sample/GetAccessTokensSample.spec.js
+++ b/test/sample/GetAccessTokensSample.spec.js
@@ -14,7 +14,7 @@ describe('GetAccessTokensSample test', () => {
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const createdToken = await CreateAndEndorseAccessTokenSample(member, member2Alias);
         const foundToken = await GetAccessTokensSample(member, member2Alias);
         assert.equal(createdToken.id, foundToken.id);

--- a/test/sample/GetTransactionSample.spec.js
+++ b/test/sample/GetTransactionSample.spec.js
@@ -17,7 +17,7 @@ describe('GetTransactionSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         const transfer = await RedeemTransferTokenSample(member2, res.id);
         const transaction = await GetTransactionSample(member, transfer);

--- a/test/sample/GetTransactionsSample.spec.js
+++ b/test/sample/GetTransactionsSample.spec.js
@@ -17,7 +17,7 @@ describe('GetTransactionsSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         await RedeemTransferTokenSample(member2, res.id);
         const transactions = await GetTransactionsSample(member);

--- a/test/sample/GetTransferTokenAttachmentsSample.spec.js
+++ b/test/sample/GetTransferTokenAttachmentsSample.spec.js
@@ -16,7 +16,7 @@ describe('GetTransferTokenAttachmentsSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenWithAttachmentSample(
             member,
             member2Alias);

--- a/test/sample/GetTransfersSample.spec.js
+++ b/test/sample/GetTransfersSample.spec.js
@@ -19,7 +19,7 @@ describe('GetTransfersSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         await RedeemTransferTokenSample(member2, res.id);
         const transfers = await GetTransfersSample(member);
@@ -34,7 +34,7 @@ describe('GetTransferSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         const redeemedTransfer = await RedeemTransferTokenSample(member2, res.id);
         const fetchedTransfer = await GetTransferSample(member, redeemedTransfer.id);
@@ -49,7 +49,7 @@ describe('GetTransferTokensSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         await RedeemTransferTokenSample(member2, res.id);
         const transferTokens = await GetTransferTokensSample(member);

--- a/test/sample/NotificationsSample.spec.js
+++ b/test/sample/NotificationsSample.spec.js
@@ -18,10 +18,7 @@ describe('NotificationsSample test', () => {
         await LinkMemberAndBankSample(payer);
         await LinkMemberAndBankSample(payee);
 
-        const payerAlias = {
-            type: 'USERNAME',
-            value: await payer.firstAlias()
-        };
+        const payerAlias = await payer.firstAlias();
         const res = await NotifyPaymentRequestSample(Token, payee, payerAlias);
         assert.isOk(res);
 

--- a/test/sample/NotifyPaymentRequestSample.spec.js
+++ b/test/sample/NotifyPaymentRequestSample.spec.js
@@ -22,10 +22,7 @@ describe('NotifyPaymentRequestSample test', () => {
             TARGET: Token.Util.generateNonce(),
         });
 
-        const payerAlias = {
-            type: 'USERNAME',
-            value: await payer.firstAlias()
-        };
+        const payerAlias = await payer.firstAlias();
         const res = await NotifyPaymentRequestSample(Token, payee, payerAlias);
         assert.equal(res, 'ACCEPTED');
     });

--- a/test/sample/RedeemAccessTokenSample.spec.js
+++ b/test/sample/RedeemAccessTokenSample.spec.js
@@ -14,7 +14,7 @@ describe('RedeemAccessTokenSample test', () => {
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseAccessTokenSample(member, member2Alias);
         const accounts = await RedeemAccessTokenSample(member2, res.id);
 

--- a/test/sample/RedeemTransferTokenSample.spec.js
+++ b/test/sample/RedeemTransferTokenSample.spec.js
@@ -16,7 +16,7 @@ describe('RedeemTransferTokenSample test', () => {
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseTransferTokenSample(member, member2Alias);
         const transfer = await RedeemTransferTokenSample(member2, res.id);
         assert.isAtLeast(transfer.payloadSignatures.length, 1);

--- a/test/sample/ReplaceAccessToken.spec.js
+++ b/test/sample/ReplaceAccessToken.spec.js
@@ -15,7 +15,7 @@ describe('ReplaceAccessTokenSample test', () => {
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         await CreateAndEndorseAccessTokenSample(member, member2Alias);
         const foundToken = await GetAccessTokensSample(member, member2Alias);
         const something = await ReplaceAccessTokenSample(member, foundToken);

--- a/test/sample/ReplaceAndEndorseAccessToken.spec.js
+++ b/test/sample/ReplaceAndEndorseAccessToken.spec.js
@@ -16,7 +16,7 @@ describe('ReplaceAndEndorseAccessTokenSample test', () => {
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
-        const member2Alias = {type: 'USERNAME', value: await member2.firstAlias()};
+        const member2Alias = await member2.firstAlias();
         await CreateAndEndorseAccessTokenSample(member, member2Alias);
         const foundToken = await GetAccessTokensSample(member, member2Alias);
         const something = await ReplaceAndEndorseAccessTokenSample(member, foundToken);


### PR DESCRIPTION
use GetAliases instead of alias hashes from member

many tests-of-samples assumed alias was a USERNAME;
change them to be alias-type tolerant