### PR TITLE
some tests created a TokenIo but just needed Util; so just use Util

### DIFF
--- a/test/http/AuthHttpClient.spec.js
+++ b/test/http/AuthHttpClient.spec.js
@@ -5,10 +5,9 @@ import 'babel-regenerator-runtime';
 import HttpClient from "../../src/http/HttpClient";
 import AuthHttpClient from "../../src/http/AuthHttpClient";
 import MemoryCryptoEngine from "../../src/security/engines/MemoryCryptoEngine";
+import Util from '../../src/Util';
 
 const devKey = require("../../src/config.json").devKey[TEST_ENV];
-const TokenIo = require('../../src');
-const Token = new TokenIo(TEST_ENV, devKey);
 
 describe('AuthHttpClient', () => {
     it('should add a second key', async () => {
@@ -59,12 +58,12 @@ describe('AuthHttpClient', () => {
             engine);
         await client.addAlias(
             res2.data.member.lastHash,
-            Token.Util.randomAlias());
+            Util.randomAlias());
         const res3 = await unauthenticatedClient.getMember(res2.data.member.id);
         assert.equal(res3.data.member.aliasHashes.length, 1);
         await client.addAlias(
             res3.data.member.lastHash,
-            Token.Util.randomAlias());
+            Util.randomAlias());
         const res4 = await unauthenticatedClient.getMember(res2.data.member.id);
         assert.equal(res4.data.member.aliasHashes.length, 2);
     });
@@ -84,10 +83,10 @@ describe('AuthHttpClient', () => {
             engine);
         await client.addAlias(
             res2.data.member.lastHash,
-            Token.Util.randomAlias());
+            Util.randomAlias());
         const res3 = await unauthenticatedClient.getMember(res2.data.member.id);
         assert.equal(res3.data.member.aliasHashes.length, 1);
-        const secondAlias = Token.Util.randomAlias();
+        const secondAlias = Util.randomAlias();
         await client.addAlias(res3.data.member.lastHash, secondAlias);
         const res4 = await unauthenticatedClient.getMember(res2.data.member.id);
         assert.equal(res4.data.member.aliasHashes.length, 2);

--- a/test/security/FileSystemPromise.spec.js
+++ b/test/security/FileSystemPromise.spec.js
@@ -2,8 +2,7 @@ const chai = require('chai');
 const assert = chai.assert;
 import 'babel-regenerator-runtime';
 import FileSystem from '../../src/security/PromiseFileSystem';
-const TokenIo = require('../../src');
-const Token = new TokenIo(TEST_ENV);
+import Util from '../../src/Util';
 
 let fs;
 let path;
@@ -30,7 +29,7 @@ describe('Filesystem', () => {
         });
 
         it('should write and read a file', async () => {
-            const randomFilename = Token.Util.generateNonce();
+            const randomFilename = Util.generateNonce();
 
             await FileSystem.writeFile(randomFilename, '12345');
             const result = await FileSystem.readFile(randomFilename);
@@ -42,7 +41,7 @@ describe('Filesystem', () => {
         });
 
         it('should fail to read a nonexistant file', async () => {
-            const randomFilename = Token.Util.generateNonce();
+            const randomFilename = Util.generateNonce();
             try {
                 await FileSystem.readFile(randomFilename);
                 return Promise.reject('Should throw an error');
@@ -52,7 +51,7 @@ describe('Filesystem', () => {
         });
 
         it('should create an empty file', async () => {
-            const randomFilename = Token.Util.generateNonce();
+            const randomFilename = Util.generateNonce();
 
             await FileSystem.writeFile(randomFilename, '');
             const result = await FileSystem.readFile(randomFilename);
@@ -64,7 +63,7 @@ describe('Filesystem', () => {
         });
 
         it('should override a file', async () => {
-            const randomFilename = Token.Util.generateNonce();
+            const randomFilename = Util.generateNonce();
 
             await FileSystem.writeFile(randomFilename, '12345');
             await FileSystem.writeFile(randomFilename, JSON.stringify({a: 1, b: 2}));

--- a/test/security/engines/BrowserCryptoEngine.spec.js
+++ b/test/security/engines/BrowserCryptoEngine.spec.js
@@ -1,8 +1,7 @@
 const chai = require('chai');
 const assert = chai.assert;
 import BrowserCryptoEngine from "../../../src/security/engines/BrowserCryptoEngine";
-const TokenIo = require('../../../src/index');
-const Token = new TokenIo(TEST_ENV);
+import Util from '../../../src/Util';
 
 describe('Browser crypto engines', () => {
     if (BROWSER) {
@@ -11,14 +10,14 @@ describe('Browser crypto engines', () => {
         });
 
         it('should create the localStorage crypto engines', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             assert.isOk(engine);
             assert.include(window.localStorage.members, memberId);
         });
 
         it('should generate keys', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const pk1 = engine.generateKey('LOW');
             const pk2 = engine.generateKey('STANDARD');
@@ -31,7 +30,7 @@ describe('Browser crypto engines', () => {
         });
 
         it('should not create a bad signer', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             try {
                 engine.createSigner('STANDARD');
@@ -42,7 +41,7 @@ describe('Browser crypto engines', () => {
         });
 
         it('should have a signer with a key id', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const pk1 = engine.generateKey('LOW');
             const signerLow = engine.createSigner('LOW');
@@ -50,7 +49,7 @@ describe('Browser crypto engines', () => {
         });
 
         it('should sign and verify', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const pk1 = engine.generateKey('LOW');
             const signer = engine.createSigner('LOW');
@@ -60,7 +59,7 @@ describe('Browser crypto engines', () => {
         });
 
         it('should sign and verify json', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const pk1 = engine.generateKey('LOW');
             const signer = engine.createSigner('LOW');
@@ -70,7 +69,7 @@ describe('Browser crypto engines', () => {
         });
 
         it('should fail to verify an invalid signature', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const pk1 = engine.generateKey('LOW');
             const signer = engine.createSigner('LOW');
@@ -85,7 +84,7 @@ describe('Browser crypto engines', () => {
         });
 
         it('should be able to create multiple engines', () => {
-            const memberId = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const engine2 = new BrowserCryptoEngine(memberId);
             const pk2 = engine2.generateKey('STANDARD');
@@ -96,9 +95,9 @@ describe('Browser crypto engines', () => {
         });
 
         it('should be able to log in with the active memberId', () => {
-            const memberId = Token.Util.generateNonce();
-            const memberId2 = Token.Util.generateNonce();
-            const memberId3 = Token.Util.generateNonce();
+            const memberId = Util.generateNonce();
+            const memberId2 = Util.generateNonce();
+            const memberId3 = Util.generateNonce();
             const engine = new BrowserCryptoEngine(memberId);
             const engine2 = new BrowserCryptoEngine(memberId2);
             const engine3 = new BrowserCryptoEngine(memberId3);

--- a/test/security/engines/MemoryCryptoEngine.spec.js
+++ b/test/security/engines/MemoryCryptoEngine.spec.js
@@ -1,18 +1,17 @@
 const chai = require('chai');
 const assert = chai.assert;
 import MemoryCryptoEngine from "../../../src/security/engines/MemoryCryptoEngine";
-const TokenIo = require('../../../src/index');
-const Token = new TokenIo(TEST_ENV);
+import Util from '../../../src/Util';
 
 describe('Memory crypto engines', () => {
     it('should create the memory crypto engines', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         assert.isOk(engine);
     });
 
     it('should generate keys', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         const pk1 = engine.generateKey('LOW');
         const pk2 = engine.generateKey('STANDARD');
@@ -25,7 +24,7 @@ describe('Memory crypto engines', () => {
     });
 
     it('should not create a bad signer', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         engine.generateKey('LOW');
         try {
@@ -37,7 +36,7 @@ describe('Memory crypto engines', () => {
     });
 
     it('should have a signer with a key id', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         const pk1 = engine.generateKey('LOW');
         const signerLow = engine.createSigner('LOW');
@@ -45,7 +44,7 @@ describe('Memory crypto engines', () => {
     });
 
     it('should sign and verify', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         const pk1 = engine.generateKey('LOW');
         const signer = engine.createSigner('LOW');
@@ -55,7 +54,7 @@ describe('Memory crypto engines', () => {
     });
 
     it('should sign and verify json', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         const pk1 = engine.generateKey('LOW');
         const signer = engine.createSigner('LOW');
@@ -65,7 +64,7 @@ describe('Memory crypto engines', () => {
     });
 
     it('should fail to verify an invalid signature', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         const pk1 = engine.generateKey('LOW');
         const signer = engine.createSigner('LOW');
@@ -80,7 +79,7 @@ describe('Memory crypto engines', () => {
     });
 
     it('should be able to create multiple engines', () => {
-        const memberId = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         engine.generateKey('LOW');
         const engine2 = new MemoryCryptoEngine(memberId);
@@ -92,9 +91,9 @@ describe('Memory crypto engines', () => {
     });
 
     it('should be able to log in with the active memberId', () => {
-        const memberId = Token.Util.generateNonce();
-        const memberId2 = Token.Util.generateNonce();
-        const memberId3 = Token.Util.generateNonce();
+        const memberId = Util.generateNonce();
+        const memberId2 = Util.generateNonce();
+        const memberId3 = Util.generateNonce();
         const engine = new MemoryCryptoEngine(memberId);
         const engine2 = new MemoryCryptoEngine(memberId2);
         const engine3 = new MemoryCryptoEngine(memberId3);


### PR DESCRIPTION
When we added devKey, we overlooked adding it in some tests--but
those tests, confusingly, still passed.

This was because those tests created a TokenIo, but only ever
used TokenIo.Util.generateNonce from it.

To avoid confusing ourselves more in the future, modified
those tests to just include Util instead of making
SDK clients.