### PR TITLE
omit sample code from esdoc; its API is not so interesting

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,6 +1,7 @@
 {
     "source": "./src",
     "destination": "./doc",
+    "excludes": ["^sample/"],
     "plugins": [
         { "name": "esdoc-standard-plugin", "option": { } },
         { "name": "esdoc-inject-script-plugin", "option": {


### PR DESCRIPTION
our esdoc https://developer.token.io/sdk/esdoc/ shows the API of our sample code . the left-hand side-nav is mostly links to this. But the sample code's API isn't so interesting, so the side-nav feels cluttered.

Historically, it was nice having the samples in the esdoc because that meant the sample code was up on the web where folks could see it. But now that sdk-js is public, folks can view the sample code on github instead.