### PR TITLE
Appless: check for no alias member

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-io",
-  "version": "1.4.102",
+  "version": "1.4.103",
   "description": "",
   "main": "dist/token-io.min.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-io",
-  "version": "1.4.101",
+  "version": "1.4.102",
   "description": "",
   "main": "dist/token-io.min.js",
   "scripts": {

--- a/src/main/Token.js
+++ b/src/main/Token.js
@@ -126,7 +126,7 @@ class Token {
                     engine,
                     this._developerKey,
                     this._globalRpcErrorCallback);
-            if (Object.keys(alias).length !== 0) {
+            if (alias && Object.keys(alias).length !== 0) {
                 await member.addAlias(alias);
             }
             return member;

--- a/src/main/Token.js
+++ b/src/main/Token.js
@@ -105,7 +105,7 @@ class Token {
      * Creates a member with a alias and a keypair, using the provided engine
      *
      * @param  {Object} alias - alias to set for member,
-     *                  empty object for a temporary member without an alias
+     *                  falsy value or empty object for a temporary member without an alias
      * @param  {Class} CryptoEngine - engine to use for key creation and storage
      * @return {Promise} member - Promise of created Member
      */

--- a/src/main/Token.js
+++ b/src/main/Token.js
@@ -104,7 +104,8 @@ class Token {
     /**
      * Creates a member with a alias and a keypair, using the provided engine
      *
-     * @param  {Object} alias - alias to set for member
+     * @param  {Object} alias - alias to set for member,
+     *                  empty object for a temporary member without an alias
      * @param  {Class} CryptoEngine - engine to use for key creation and storage
      * @return {Promise} member - Promise of created Member
      */
@@ -125,7 +126,9 @@ class Token {
                     engine,
                     this._developerKey,
                     this._globalRpcErrorCallback);
-            await member.addAlias(alias);
+            if (Object.keys(alias).length !== 0) {
+                await member.addAlias(alias);
+            }
             return member;
         });
     }

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -41,3 +41,11 @@ describe('Token library', () => {
         });
     });
 });
+
+describe('Token library', () => {
+    it('should create a member with no aliases', async () => {
+        const guest = await Token.createMember({}, Token.MemoryCryptoEngine);
+        const aliases = await guest.aliases();
+        assert.isUndefined(aliases);
+    });
+});

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -43,9 +43,12 @@ describe('Token library', () => {
 });
 
 describe('Token library', () => {
-    it('should create a member with no aliases', async () => {
+    it('should create two members with no aliases', async () => {
         const guest = await Token.createMember({}, Token.MemoryCryptoEngine);
         const aliases = await guest.aliases();
+        const guest2 = await Token.createMember(null, Token.MemoryCryptoEngine);
+        const aliases2 = await guest2.aliases();
         assert.isUndefined(aliases);
+        assert.isUndefined(aliases2);
     });
 });


### PR DESCRIPTION
No reason to create temp members with aliases for appless, this change avoids email verifications for appless users. 