### PR TITLE
Doc 215 access sample more obvious

### DIFF
--- a/src/sample/CreateAndEndorseAccessTokenSample.js
+++ b/src/sample/CreateAndEndorseAccessTokenSample.js
@@ -9,7 +9,8 @@ export default async (grantor, granteeAlias) => {
     // Grantor creates the token with the desired terms
     const token = await grantor.createAccessToken(
         granteeAlias,
-        [{allAccounts: {}}, {allBalances: {}}]);
+        [{allAccounts: {}},   // user can call getAccounts
+         {allBalances: {}}]); // for each account, can getBalance
 
     // Grantor endorses the token, creating and submitting a digital signature
     const result = await grantor.endorseToken(token);

--- a/src/sample/CreateAndEndorseAccessTokenSample.js
+++ b/src/sample/CreateAndEndorseAccessTokenSample.js
@@ -9,7 +9,7 @@ export default async (grantor, granteeAlias) => {
     // Grantor creates the token with the desired terms
     const token = await grantor.createAccessToken(
         granteeAlias,
-        [{allAccounts: {}}]);
+        [{allAccounts: {}}, {allBalances: {}}]);
 
     // Grantor endorses the token, creating and submitting a digital signature
     const result = await grantor.endorseToken(token);

--- a/src/sample/RedeemAccessTokenSample.js
+++ b/src/sample/RedeemAccessTokenSample.js
@@ -4,7 +4,7 @@
  *
  * @param {Member} grantee - grantee member
  * @param {string} tokenId - id of the token to redeem
- * @return {Array} accounts - grantor accounts
+ * @return {Object} balance0 - balance of one account
  */
 export default async (grantee, tokenId) => {
     // Use the access token, now making API calls
@@ -12,7 +12,10 @@ export default async (grantee, tokenId) => {
     grantee.useAccessToken(tokenId);
     const accounts = await grantee.getAccounts();
 
-    // Clear the access token
+    // Get informtion we want:
+    const balance0 = await grantee.getBalance(accounts[0].id);
+
+    // When done using access, clear the access token:
     grantee.clearAccessToken();
-    return accounts;
+    return balance0.current;
 };

--- a/src/sample/ReplaceAccessTokenSample.js
+++ b/src/sample/ReplaceAccessTokenSample.js
@@ -8,7 +8,7 @@
 export default async (grantor, oldToken) => {
     const replaceResult = await grantor.replaceAccessToken(
         oldToken,
-        [{allTransactions: {}}]);
+        [{allAddresses: {}}]);
     const endorseResult = await grantor.endorseToken(
         replaceResult.token);
     return endorseResult.token;

--- a/src/sample/ReplaceAccessTokenSample.js
+++ b/src/sample/ReplaceAccessTokenSample.js
@@ -8,7 +8,9 @@
 export default async (grantor, oldToken) => {
     const replaceResult = await grantor.replaceAccessToken(
         oldToken,
-        [{allAddresses: {}}]);
+        [{allAccounts: {}},
+         {allBalances: {}},
+         {allAddresses: {}}]);
     const endorseResult = await grantor.endorseToken(
         replaceResult.token);
     return endorseResult.token;

--- a/src/sample/ReplaceAndEndorseAccessTokenSample.js
+++ b/src/sample/ReplaceAndEndorseAccessTokenSample.js
@@ -8,6 +8,8 @@
 export default async (grantor, oldToken) => {
     const result = await grantor.replaceAndEndorseAccessToken(
         oldToken,
-        [{allAddresses: {}}]);
+        [{allAccounts: {}},
+         {allBalances: {}},
+         {allAddresses: {}}]);
     return result.token;
 };

--- a/src/sample/ReplaceAndEndorseAccessTokenSample.js
+++ b/src/sample/ReplaceAndEndorseAccessTokenSample.js
@@ -8,6 +8,6 @@
 export default async (grantor, oldToken) => {
     const result = await grantor.replaceAndEndorseAccessToken(
         oldToken,
-        [{allTransactions: {}}]);
+        [{allAddresses: {}}]);
     return result.token;
 };

--- a/test/sample/RedeemAccessTokenSample.spec.js
+++ b/test/sample/RedeemAccessTokenSample.spec.js
@@ -16,8 +16,8 @@ describe('RedeemAccessTokenSample test', () => {
 
         const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseAccessTokenSample(member, member2Alias);
-        const accounts = await RedeemAccessTokenSample(member2, res.id);
+        const balance = await RedeemAccessTokenSample(member2, res.id);
 
-        assert.isAtLeast(accounts.length, 1);
+        assert.isAtLeast(parseFloat(balance.value), 1);
     });
 });


### PR DESCRIPTION
don't just use allAccounts ; if you see "allAccounts" but not, e.g., "allBalances", it's easy to to think allAccounts means "everything about all accounts"

Old sample was useToken , getAccounts, (do nothing with them), clearToken. Change to show using the accounts before clearToken.

in replace examples, don't replace one access with unrelated access.