### PR TITLE
sample code += use access token that maybe does not have allAccounts

### DIFF
--- a/src/sample/ProvisionDeviceSample.js
+++ b/src/sample/ProvisionDeviceSample.js
@@ -3,7 +3,7 @@
  * That is, how a member logs in with one device when their
  * account "lives" on another device.
  */
-class PollNotificationsSample {
+class ProvisionDeviceSample {
 
     /**
      * Provision device: generate a key and ask member
@@ -49,4 +49,4 @@ class PollNotificationsSample {
         return localLoggedIn;
     }
 }
-export default PollNotificationsSample;
+export default ProvisionDeviceSample;

--- a/src/sample/RedeemAccessTokenSample.js
+++ b/src/sample/RedeemAccessTokenSample.js
@@ -1,21 +1,75 @@
 /**
- * Redeems an information access token token, in order to acquire names of the grantor's
- * accounts.
- *
- * @param {Member} grantee - grantee member
- * @param {string} tokenId - id of the token to redeem
- * @return {Object} balance0 - balance of one account
+ * Sample code illustrating how a grantee might use an access token.
  */
-export default async (grantee, tokenId) => {
-    // Use the access token, now making API calls
-    // on behalf of the grantor, and get accounts
-    grantee.useAccessToken(tokenId);
-    const accounts = await grantee.getAccounts();
+class RedeemAccessTokenSample {
+    /**
+     * Redeems an information access token token to fetch an account balance.
+     * Assumes the token grants "allAccounts" access.
+     *
+     * @param {Member} grantee - grantee member
+     * @param {string} tokenId - id of the token to redeem
+     * @return {Object} balance0 - balance of one account
+     */
+    static async use(grantee, tokenId) {
+        // Use the access token, now making API calls
+        // on behalf of the grantor, and get accounts
+        grantee.useAccessToken(tokenId);
+        const accounts = await grantee.getAccounts();
 
-    // Get informtion we want:
-    const balance0 = await grantee.getBalance(accounts[0].id);
+        // Get informtion we want:
+        const balance0 = await grantee.getBalance(accounts[0].id);
 
-    // When done using access, clear the access token:
-    grantee.clearAccessToken();
-    return balance0.current;
-};
+        // When done using access, clear the access token:
+        grantee.clearAccessToken();
+        return balance0.current;
+    }
+
+    /**
+     * Redeems an information access token token to fetch an account balance.
+     * Does not assume the token grants "allAccounts" access.
+     *
+     * @param {Member} grantee - grantee member
+     * @param {string} tokenId - id of the token to redeem
+     * @return {Object} balance0 - balance of one account
+     */
+    static async carefullyUse(grantee, tokenId) {
+        var accessToken = await grantee.getToken(tokenId);
+        while (accessToken.replacedByTokenId) {
+            accessToken = await grantee.getToken(accessToken.replacedByTokenId);
+        }
+        var accountIds = {};
+        var haveAllBalancesAccess = false;
+        var haveAllAccountsAccess = false;
+        var i;
+        for (i = 0; i < accessToken.payload.access.resources.length; i++) {
+            const resource = accessToken.payload.access.resources[i];
+            if (resource.balance && resource.balance.accountId) {
+                accountIds[resource.balance.accountId] = true;
+                continue;
+            }
+            if (resource.allBalances) {
+                haveAllBalancesAccess = true;
+                continue;
+            }
+            if (resource.allAccounts) {
+                haveAllAccountsAccess = true;
+                continue;
+            }
+        }
+        grantee.useAccessToken(accessToken.id);
+        if (haveAllBalancesAccess && haveAllAccountsAccess) {
+            const accounts = await grantee.getAccounts();
+            for (i = 0; i < accounts.length; i++) {
+                accountIds[accounts[i].id] = true;
+            }
+        }
+        if (Object.keys(accountIds).length < 1) {
+            return {};
+        }
+        const account0Id = Object.keys(accountIds)[0];
+        const balance0 = await grantee.getBalance(account0Id);
+        grantee.clearAccessToken();
+        return balance0.current;
+    }
+}
+export default RedeemAccessTokenSample;

--- a/test/sample/RedeemAccessTokenSample.spec.js
+++ b/test/sample/RedeemAccessTokenSample.spec.js
@@ -9,15 +9,40 @@ import CreateAndEndorseAccessTokenSample from '../../src/sample/CreateAndEndorse
 import RedeemAccessTokenSample from '../../src/sample/RedeemAccessTokenSample';
 
 describe('RedeemAccessTokenSample test', () => {
-    it('Should run the sample', async () => {
+    it('Should run the "use" sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();
         const res = await CreateAndEndorseAccessTokenSample(member, member2Alias);
-        const balance = await RedeemAccessTokenSample(member2, res.id);
+        const balance = await RedeemAccessTokenSample.use(member2, res.id);
 
         assert.isAtLeast(parseFloat(balance.value), 1);
+    });
+
+    it('Should run the "careful" sample', async () => {
+        const grantor = await CreateMemberSample();
+        const auth1 = await grantor.createTestBankAccount(200, 'EUR');
+        const auth2 = await grantor.createTestBankAccount(200, 'USD');
+        const account1 = (await grantor.linkAccounts(auth1))[0];
+        const account2 = (await grantor.linkAccounts(auth2))[0];
+
+        const grantee = await CreateMemberSample();
+
+        const granteeAlias = await grantee.firstAlias();
+        const token1 = await CreateAndEndorseAccessTokenSample(grantor, granteeAlias);
+        const balance1 = await RedeemAccessTokenSample.carefullyUse(grantee, token1.id);
+        assert.isAtLeast(parseFloat(balance1.value), 1);
+
+        await grantor.replaceAndEndorseAccessToken(
+            token1,
+            [{account: {accountId: account1.id}},
+             {account: {accountId: account2.id}},
+             {balance: {accountId: account1.id}},
+             {balance: {accountId: account2.id}}]);
+
+        const balance2 = await RedeemAccessTokenSample.carefullyUse(grantee, token1.id);
+        assert.isAtLeast(parseFloat(balance2.value), 1);
     });
 });


### PR DESCRIPTION
so far, our redeem-access-token sample code shows how to use a token that has allAccounts. But if the token-grantor replaces that allAccounts with something more specific, e.g., edits the permissions in our iPhone app, that sample code fails to fetch any data. This new sample code shows how to use allAccounts if granted else use more-specific permissions.

bonus: fix silly copy-pasted class name.