### PR TITLE
ease understanding of CryptoEngine interface

### DIFF
--- a/src/security/Crypto.js
+++ b/src/security/Crypto.js
@@ -76,6 +76,25 @@ class Crypto {
     }
 
     /**
+     * Helper function for crypto engine createSigner:
+     * returns a signer that uses a keypair.
+     *
+     * @param {Key} keypair, such as returned by Token.Crypto.generatekeys
+     * @return {Object} signer, as expected from a crypto engine createSigner
+     */
+    static createSignerFromKeypair(keypair) {
+        return {
+            sign: (message) => {
+                return Crypto.sign(message, keypair);
+            },
+            signJson: (json) => {
+                return Crypto.signJson(json, keypair);
+            },
+            getKeyId: () => keypair.id,
+        };
+    }
+
+    /**
      * Verifies a signature on json. Throws if verification fails.
      *
      * @param {Object} json - json message to verify
@@ -102,6 +121,25 @@ class Crypto {
             throw new Error(
                 `Invalid signature ${signature} on message ${message} with pk ${publicKey}`);
         }
+    }
+
+    /**
+     * Helper function for crypto engine createVerifier:
+     * returns a signer that uses a keypair.
+     *
+     * @param {Key} keypair, such as returned by Token.Crypto.generatekeys. (It's OK
+     *                       if this "keypair" has no secretKey.)
+     * @return {Object} verifier, as expected from a crypto engine createVerifier
+     */
+    static createVerifierFromKeypair(keypair) {
+        return {
+            verify: (message, signature) => {
+                return Crypto.verify(message, signature, keypair.publicKey);
+            },
+            verifyJson: (json, signature) => {
+                return Crypto.verifyJson(json, signature, keypair.publicKey);
+            }
+        };
     }
 
     /**

--- a/src/security/engines/BrowserCryptoEngine.js
+++ b/src/security/engines/BrowserCryptoEngine.js
@@ -118,15 +118,7 @@ class BrowserCryptoEngine {
         const loadedMember = this._loadMember();
         for (let keys of loadedMember.keys) {
             if (keys.level === securityLevel) {
-                return {
-                    sign: (message) => {
-                        return Crypto.sign(message, keys);
-                    },
-                    signJson: (json) => {
-                        return Crypto.signJson(json, keys);
-                    },
-                    getKeyId: () => keys.id,
-                };
+                return Crypto.createSignerFromKeyPair(keys);
             }
         }
         throw new Error(`No key with level ${securityLevel} found`);
@@ -143,14 +135,7 @@ class BrowserCryptoEngine {
         const loadedMember = this._loadMember();
         for (let keys of loadedMember.keys) {
             if (keys.id === keyId) {
-                return {
-                    verify: (message, signature) => {
-                        return Crypto.verify(message, signature, keys.publicKey);
-                    },
-                    verifyJson: (json, signature) => {
-                        return Crypto.verifyJson(json, signature, keys.publicKey);
-                    }
-                };
+                return Crypto.createVerifierFromKeypair(keys);
             }
         }
         throw new Error(`No key with id ${keyId} found`);

--- a/src/security/engines/MemoryCryptoEngine.js
+++ b/src/security/engines/MemoryCryptoEngine.js
@@ -105,15 +105,7 @@ class MemoryCryptoEngine {
         const loadedMember = this._loadMember();
         for (let keys of loadedMember.keys) {
             if (keys.level === securityLevel) {
-                return {
-                    sign: (message) => {
-                        return Crypto.sign(message, keys);
-                    },
-                    signJson: (json) => {
-                        return Crypto.signJson(json, keys);
-                    },
-                    getKeyId: () => keys.id,
-                };
+                return Crypto.createSignerFromKeypair(keys);
             }
         }
         throw new Error(`No key with level ${securityLevel} found`);
@@ -130,14 +122,7 @@ class MemoryCryptoEngine {
         const loadedMember = this._loadMember();
         for (let keys of loadedMember.keys) {
             if (keys.id === keyId) {
-                return {
-                    verify: (message, signature) => {
-                        return Crypto.verify(message, signature, keys.publicKey);
-                    },
-                    verifyJson: (json, signature) => {
-                        return Crypto.verifyJson(json, signature, keys.publicKey);
-                    }
-                };
+                return Crypto.createVerifierFromKeypair(keys);
             }
         }
         throw new Error(`No key with id ${keyId} found`);

--- a/src/security/engines/README.md
+++ b/src/security/engines/README.md
@@ -1,0 +1,137 @@
+CryptoEngines
+=============
+
+This directory contains implementations of the "CryptoEngine interface."
+That is, they are classes that implement methods inspired by the Java interface
+https://github.com/tokenio/sdk-java/blob/master/lib/src/main/java/io/token/security/CryptoEngine.java .
+If you want to store members' crypto keys in a way that's not already implemented
+here, you want to create your own ____CryptoEngine class.
+As described below, to generate and use those keys, the class can use Token.Crypto functions.
+
+   /**
+    * Constructs the engine, using an existing member/keys if it is in localStorage
+    *
+    * @param {string} memberId - memberId of the member we want to create the engine for
+    */
+   constructor(memberId) {}
+
+   /**
+     * Generates and stores a new keypair, replacing the corresponding
+     * old key (with the same security level) if there was one.
+     *
+     * @param {string} securityLevel - security level of the key we want to create
+     *                 "LOW" "STANDARD" "PRIVILEGED"
+     * @return {Key} key - generated key
+     */
+   generateKey(securityLevel) {
+      // generate a keypair
+      const keypair = Token.Crypto.generateKeys(securityLevel);
+
+      ...store keypair...
+
+      delete keypair.secretKey; // we're about to return keypair, but want to omit secretKey
+      return keypair;
+    }
+
+    /**
+     * Creates a signer object using the key with the specified key level. This can sign
+     * strings and JSON objects.
+     *
+     * @param {string} securityLevel - security level of the key we want to use to sign
+     *                 "LOW" "STANDARD" "PRIVILEGED"
+     * @return {Object} signer - signer object
+     */
+    async createSigner(securityLevel) {
+        ...load keypair...
+        if (keypair) {
+          return Token.Crypto.createSignerFromKeypair(keypair);
+        } else {
+          throw new Error(`No key with level ${securityLevel} found`);
+        }
+    }
+
+    /**
+     * Creates a verifier object using the key with the specified ID. This can verify
+     * signatures created by a signer.
+     *
+     * @param {string} keyId - ID of the key to use. It's OK if this "keypair" has no
+     *                         secretKey field.
+     * @return {Object} verifier - verifier object
+     */
+    async createVerifier(keyId) {
+       ...load keypair...
+       if (keypair) {
+         return Token.Crypto.createVerifierFromKeypair(keypair);
+       } else {
+         throw new Error(`No key with id ${keyId} found`);
+       }
+    }
+
+    /**
+     * Optional. BrowserCryptoEngine ("localStorage crypto engine") implements this;
+     * this is how Token's Merchant Checkout "remembers" who the customer is.
+     *
+     * Get's the currently active memberId. This allows login without caching memberId somewhere
+     *
+     * @return {string} memberId - active memberId
+     */
+    getActiveMemberId() {}
+
+Signer: createSigner returns an object that implements the "Signer interface".
+That is, they implement methods inspired by the Java interface
+https://github.com/tokenio/lib-security/blob/master/lib/src/main/java/io/token/security/Signer.java
+The easiest way to create one is to call Token.Crypto.createSignerFromKeypair(keypair),
+but if you want to make your own, implement the functions:
+
+    /**
+     * Return signature of the string
+     * @param {string} message - string to sign
+     * @return {string} signature - crypto signature of message
+     */
+    sign(message) {
+        return Token.Crypto.sign(message, this._keypair);
+    }
+
+    /**
+     * Return signature of the object, JSON-ified
+     * @param {object} json - object to sign
+     * @return {string} signature - crypto signature of the JSONified structure
+     */
+    signJson(json) {
+        // stringify = require('json-stable-stringify')
+        return Token.Crypto.sign(stringify(message), this._keypair);
+    }
+
+    /**
+     * Return id of key used for signing.
+     * @return {string} keyId - key ID
+     */
+    getKeyId() {
+        return this._keypair.id;
+    }
+
+Verifier: createVerifier returns an object that implements the "Verifier interface".
+That is, they implement methods inspired by the Java interface
+https://github.com/tokenio/lib-security/blob/master/lib/src/main/java/io/token/security/Verifier.java
+The easiest way to create one is to call Token.Crypto.createVerifierFromKeypair(keypair),
+but if you want to make your own, implement the functions:
+
+    /**
+     * Verify the signature goes with the passed message string.
+     * @param {string} message - message that was signed
+     * @param {string} signature - crypto signature
+     * @return {boolean} is signature OK
+     */
+    verify(message, signature) {
+        return Token.Crypto.verify(message, signature, this._keypair.publicKey);
+    }
+    /**
+     * Verify the signature goes with the passed structure
+     * @param {Object} json - Object that was signed
+     * @param {string} signature - crypto signature
+     * @return {boolean} is signature OK
+     */
+    verifyJson: (json, signature) => {
+        return Token.Crypto.verifyJson(json, signature, this._keypair.publicKey);
+    }
+    

--- a/src/security/engines/UnsecuredFileCryptoEngine.js
+++ b/src/security/engines/UnsecuredFileCryptoEngine.js
@@ -25,7 +25,7 @@ class UnsecuredFileCryptoEngine {
     }
 
     /**
-     * Constructs the engine, with no keys
+     * Constructs the engine
      *
      * @param {string} memberId - memberId of the member we want to create the engine for
      */
@@ -42,7 +42,7 @@ class UnsecuredFileCryptoEngine {
 
         this._member = {
             id: memberId,
-            keys: [],
+            keys: [], // filled in by _loadMember() as needed
         };
     }
 
@@ -94,15 +94,7 @@ class UnsecuredFileCryptoEngine {
         await this._loadMember();
         for (let keys of this._member.keys) {
             if (keys.level === securityLevel) {
-                return {
-                    sign: (message) => {
-                        return Crypto.sign(message, keys);
-                    },
-                    signJson: (json) => {
-                        return Crypto.signJson(json, keys);
-                    },
-                    getKeyId: () => keys.id,
-                };
+                return Crypto.createSignerFromKeypair(keys);
             }
         }
         throw new Error(`No key with level ${securityLevel} found`);
@@ -119,14 +111,7 @@ class UnsecuredFileCryptoEngine {
         await this._loadMember();
         for (let keys of this._member.keys) {
             if (keys.id === keyId) {
-                return {
-                    verify: (message, signature) => {
-                        return Crypto.verify(message, signature, keys.publicKey);
-                    },
-                    verifyJson: (json, signature) => {
-                        return Crypto.verifyJson(json, signature, keys.publicKey);
-                    }
-                };
+                return Crypto.createVerifierFromKeypair(keys);
             }
         }
         throw new Error(`No key with id ${keyId} found`);


### PR DESCRIPTION
pull some "common code" out of crypto engines and put it
into Crypto.js. It wasn't super-boiler-plate-y; but this
way seems easier to understand "we expect to you customize
THIS part; we expect you to do THIS part in 'the usual way'"

Add a README.md file that spells out what the
"CryptoEngine interface" means in this duck-type-y JS world.