### PR TITLE
un-break BrowserCryptoEngine by fixing typo

### DIFF
--- a/src/security/engines/BrowserCryptoEngine.js
+++ b/src/security/engines/BrowserCryptoEngine.js
@@ -118,7 +118,7 @@ class BrowserCryptoEngine {
         const loadedMember = this._loadMember();
         for (let keys of loadedMember.keys) {
             if (keys.level === securityLevel) {
-                return Crypto.createSignerFromKeyPair(keys);
+                return Crypto.createSignerFromKeypair(keys);
             }
         }
         throw new Error(`No key with level ${securityLevel} found`);


### PR DESCRIPTION
Guess who forgot we had separate tests for
browser on his recent CryptoEngine change?