### PR TITLE
WP-199: fixing step up notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-io",
-  "version": "1.4.112",
+  "version": "1.4.113",
   "description": "",
   "main": "dist/token-io.min.js",
   "scripts": {

--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -243,7 +243,7 @@ class AuthHttpClient {
     async triggerBalanceStepUpNotification(accountIds) {
         const req = {
             balanceStepUp: {
-                accountIds
+                accountId: accountIds
             }
         };
         const request = {

--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -216,10 +216,59 @@ class AuthHttpClient {
         return this._instance(request);
     }
 
-    async triggerStepUpNotification(stepUp) {
-        const type = stepUp.tokenId ? 'tokenStepUp' : 'requestStepUp';
+    /**
+     * Trigger a token step up notification.
+     *
+     * @param {String} tokenId - token id
+     * @return {Object} response - response to the Api call
+     */
+    async triggerTokenStepUpNotification(tokenId) {
         const req = {
-            [type]: stepUp
+            tokenStepUp: {
+                tokenId
+            }
+        };
+        const request = {
+            method: 'post',
+            url: `/notify/stepup`,
+            data: req
+        };
+        return this._instance(request);
+    }
+
+    /**
+     * Trigger a balance step up notification.
+     *
+     * @param {Array} accountIds - array of account ids
+     * @return {Object} response - response to the Api call
+     */
+    async triggerBalanceStepUpNotification(accountIds) {
+        const req = {
+            balanceStepUp: {
+                accountIds
+            }
+        };
+        const request = {
+            method: 'post',
+            url: `/notify/stepup`,
+            data: req
+        };
+        return this._instance(request);
+    }
+
+    /**
+     * Trigger a transaction step up notification.
+     *
+     * @param {string} accountId - account id
+     * @param {string} transactionId - transaction id
+     * @return {Object} response - response to the Api call
+     */
+    async triggerTransactionStepUpNotification(accountId, transactionId) {
+        const req = {
+            transactionStepUp: {
+                accountId: accountId,
+                transactionId: transactionId
+            }
         };
         const request = {
             method: 'post',

--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -219,14 +219,12 @@ class AuthHttpClient {
     /**
      * Trigger a token step up notification.
      *
-     * @param {String} tokenId - token id
+     * @param {Object} stepUp - token step up notification payload
      * @return {Object} response - response to the Api call
      */
-    async triggerTokenStepUpNotification(tokenId) {
+    async triggerStepUpNotification(stepUp) {
         const req = {
-            tokenStepUp: {
-                tokenId
-            }
+            tokenStepUp: stepUp
         };
         const request = {
             method: 'post',

--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -266,8 +266,8 @@ class AuthHttpClient {
     async triggerTransactionStepUpNotification(accountId, transactionId) {
         const req = {
             transactionStepUp: {
-                accountId: accountId,
-                transactionId: transactionId
+                accountId,
+                transactionId
             }
         };
         const request = {

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -425,12 +425,12 @@ export default class Member {
     /**
      * Triggers a token step up notification on the user's app
      *
-     * @param {String} tokenId - token id
+     * @param {Object} stepUp - token step up notification payload
      * @return {Promise} - notification status
      */
-    triggerTokenStepUpNotification(tokenId) {
-        return Util.callAsync(this.triggerTokenStepUpNotification, async () => {
-            const res = await this._client.triggerTokenStepUpNotification(tokenId);
+    triggerStepUpNotification(stepUp) {
+        return Util.callAsync(this.triggerStepUpNotification, async () => {
+            const res = await this._client.triggerStepUpNotification(stepUp);
             return res.data.status;
         });
     }

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -423,14 +423,39 @@ export default class Member {
     }
 
     /**
-     * Triggers a step up notification on the user's app
+     * Triggers a token step up notification on the user's app
      *
-     * @param {object} stepUp - can be tokenStepUp or requestStepUp
+     * @param {String} tokenId - token id
      * @return {Promise} - notification status
      */
-    triggerStepUpNotification(stepUp) {
+    triggerTokenStepUpNotification(tokenId) {
+        return Util.callAsync(this.triggerTokenStepUpNotification, async () => {
+            const res = await this._client.triggerStepUpNotification(tokenId);
+            return res.data.status;
+        });
+    }
+
+    /**
+     * Triggers a balance step up notification on the user's app
+     * @param {Array} accountIds - array of account ids
+     * @return {Promise} - notification status
+     */
+    triggerBalanceStepUpNotification(accountIds) {
+        return Util.callAsync(this.triggerBalanceStepUpNotification, async () => {
+            const res = await this._client.triggerBalanceStepUpNotification(accountIds);
+            return res.data.status;
+        });
+    }
+
+    /**
+     * Triggers a transaction step up notification on the user's app
+     * @param {String} accountId - account id
+     * @param {String} transactionId - transaction id
+     * @return {Promise} - notification status
+     */
+    triggerStepUpNotification(accountId, transactionId) {
         return Util.callAsync(this.triggerStepUpNotification, async () => {
-            const res = await this._client.triggerStepUpNotification(stepUp);
+            const res = await this._client.triggerStepUpNotification(accountId, transactionId);
             return res.data.status;
         });
     }

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -430,7 +430,7 @@ export default class Member {
      */
     triggerTokenStepUpNotification(tokenId) {
         return Util.callAsync(this.triggerTokenStepUpNotification, async () => {
-            const res = await this._client.triggerStepUpNotification(tokenId);
+            const res = await this._client.triggerTokenStepUpNotification(tokenId);
             return res.data.status;
         });
     }
@@ -453,9 +453,11 @@ export default class Member {
      * @param {String} transactionId - transaction id
      * @return {Promise} - notification status
      */
-    triggerStepUpNotification(accountId, transactionId) {
-        return Util.callAsync(this.triggerStepUpNotification, async () => {
-            const res = await this._client.triggerStepUpNotification(accountId, transactionId);
+    triggerTransactionStepUpNotification(accountId, transactionId) {
+        return Util.callAsync(this.triggerTransactionStepUpNotification, async () => {
+            const res = await this._client.triggerTransactionStepUpNotification(
+                accountId,
+                transactionId);
             return res.data.status;
         });
     }


### PR DESCRIPTION
Implementing changes to the step up notifications, they were still using the outdated api. 

Quick question Harry, what exactly needs to be changed in the other web related services so that the notifications get triggered when getBalance/getTransaction fails?

