### PR TITLE
PL-164: add methods to generate temporary keys

### DIFF
--- a/src/http/AuthHttpClient.js
+++ b/src/http/AuthHttpClient.js
@@ -1056,7 +1056,8 @@ class AuthHttpClient {
                             id: key.id,
                             publicKey: Crypto.strKey(key.publicKey),
                             level: key.level,
-                            algorithm: key.algorithm
+                            algorithm: key.algorithm,
+                            expiresAtMs: key.expiresAtMs || undefined
                         }
                     }
                 }
@@ -1082,7 +1083,8 @@ class AuthHttpClient {
                         id: key.id,
                         publicKey: Crypto.strKey(key.publicKey),
                         level: key.level,
-                        algorithm: key.algorithm
+                        algorithm: key.algorithm,
+                        expiresAtMs: key.expiresAtMs || undefined
                     }
                 }
             }))

--- a/src/security/Crypto.js
+++ b/src/security/Crypto.js
@@ -53,6 +53,19 @@ class Crypto {
     }
 
     /**
+     * Generates a temporary keypair to use with the token System
+     *
+     * @param {string} keyLevel - desired security level of key
+     * @param {string} expirationMs - expiration date of the key in milliseconds
+     * @return {object} keyPair - keyPair
+     */
+    static generateTemporaryKeys(keyLevel, expirationMs) {
+        const keyPair = this.generateKeys(keyLevel);
+        keyPair.expiresAtMs = expirationMs;
+        return keyPair;
+    }
+
+    /**
      * Signs a json object and returns the signature
      *
      * @param {object} json - object to sign

--- a/src/security/engines/KeyStoreCryptoEngine.js
+++ b/src/security/engines/KeyStoreCryptoEngine.js
@@ -34,6 +34,22 @@ class KeyStoreCryptoEngine {
     }
 
     /**
+     * Generate a keypair with expiration date and store it.
+     *
+     * @param {string} level - privilege level "LOW", "STANDARD", "PRIVILEGED"
+     * @param {string} expirationMs - expiration date of the key in milliseconds
+     * @return {Object} key
+     */
+    async generateTemporaryKey(level, expirationMs) {
+        const keypair = Crypto.generateTemporaryKeys(level, expirationMs);
+        var stored = await this._keystore.put(this._memberId, keypair);
+        if (stored && stored.secretKey) {
+            delete stored.secretKey;
+        }
+        return stored;
+    }
+
+    /**
      * Create a signer. Assumes we previously generated the relevant key.
      *
      * @param {string} level - privilege level "LOW", "STANDARD", "PRIVILEGED"


### PR DESCRIPTION
Why is expirationMs a string, you ask? Well, either string or number is fine for the conversion to a protobuf object because protobuf supports both number -> int64 and string -> int64 mappings. However, when directory verifies the signature against the request payload, it converts the payload to JSON and the int64 expiration date gets converted to a string. (Deceptively, this conversion to string only occurs in the toJson call used at the end--when the log prints the payload using toString(), it appears as a number.) Therefore, we must use string for expirationMs lest we get an InvalidSignature exception.