### PR TITLE
PL-1680: added async alias verification support in tests

### DIFF
--- a/test/http/AuthHttpClient.spec.js
+++ b/test/http/AuthHttpClient.spec.js
@@ -6,6 +6,7 @@ import HttpClient from "../../src/http/HttpClient";
 import AuthHttpClient from "../../src/http/AuthHttpClient";
 import MemoryCryptoEngine from "../../src/security/engines/MemoryCryptoEngine";
 import Util from '../../src/Util';
+import TestUtil from '../TestUtil';
 
 const devKey = require("../../src/config.json").devKey[TEST_ENV];
 
@@ -57,15 +58,20 @@ describe('AuthHttpClient', () => {
             [pk1, pk2, pk3],
             engine);
         await client.addAlias(
-            res2.data.member.lastHash,
-            Util.randomAlias());
-        const res3 = await unauthenticatedClient.getMember(res2.data.member.id);
-        assert.equal(res3.data.member.aliasHashes.length, 1);
+                res2.data.member.lastHash,
+                Util.randomAlias());
+        let res3;
+        await TestUtil.waitUntil(async () => {
+            res3 = await unauthenticatedClient.getMember(res2.data.member.id);
+            assert.equal(res3.data.member.aliasHashes.length, 1);
+        });
         await client.addAlias(
-            res3.data.member.lastHash,
-            Util.randomAlias());
-        const res4 = await unauthenticatedClient.getMember(res2.data.member.id);
-        assert.equal(res4.data.member.aliasHashes.length, 2);
+                res3.data.member.lastHash,
+                Util.randomAlias());
+        await TestUtil.waitUntil(async () => {
+            const res4 = await unauthenticatedClient.getMember(res2.data.member.id);
+            assert.equal(res4.data.member.aliasHashes.length, 2);
+        });
     });
 
     it('should remove aliases', async () => {
@@ -84,12 +90,18 @@ describe('AuthHttpClient', () => {
         await client.addAlias(
             res2.data.member.lastHash,
             Util.randomAlias());
-        const res3 = await unauthenticatedClient.getMember(res2.data.member.id);
-        assert.equal(res3.data.member.aliasHashes.length, 1);
+        let res3;
+        await TestUtil.waitUntil(async () => {
+            res3 = await unauthenticatedClient.getMember(res2.data.member.id);
+            assert.equal(res3.data.member.aliasHashes.length, 1);
+        });
         const secondAlias = Util.randomAlias();
         await client.addAlias(res3.data.member.lastHash, secondAlias);
-        const res4 = await unauthenticatedClient.getMember(res2.data.member.id);
-        assert.equal(res4.data.member.aliasHashes.length, 2);
+        let res4;
+        await TestUtil.waitUntil(async () => {
+            res4 = await unauthenticatedClient.getMember(res2.data.member.id);
+            assert.equal(res4.data.member.aliasHashes.length, 2);
+        });
         const res5 = await client.removeAlias(res4.data.member.lastHash, secondAlias);
         assert.equal(res5.data.member.aliasHashes.length, 1);
     });

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -12,12 +12,18 @@ describe('Token library', () => {
         const alias2 = Token.Util.randomAlias();
 
         const member1 = await Token.createMember(alias1, Token.MemoryCryptoEngine);
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member1.firstAlias());
+        });
         await member1.subscribeToNotifications("iron");
         const auth = await member1.createTestBankAccount(100000, 'EUR');
         const accounts = await member1.linkAccounts(auth);
         const account = accounts[0];
 
         const member2 = await Token.createMember(alias2, Token.MemoryCryptoEngine);
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member2.firstAlias());
+        });
 
         const token = await member1.createTransferToken(100.00, 'EUR')
             .setAccountId(account.id)

--- a/test/sample/CancelAccessTokenSample.spec.js
+++ b/test/sample/CancelAccessTokenSample.spec.js
@@ -7,11 +7,16 @@ import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import CreateAndEndorseAccessTokenSample from '../../src/sample/CreateAndEndorseAccessTokenSample';
 import CancelAccessTokenSample from '../../src/sample/CancelAccessTokenSample';
+import TestUtil from '../TestUtil';
 
 describe('CancelAccessTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();

--- a/test/sample/CancelTransferTokenSample.spec.js
+++ b/test/sample/CancelTransferTokenSample.spec.js
@@ -8,11 +8,16 @@ import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import CreateAndEndorseTransferTokenSample
   from '../../src/sample/CreateAndEndorseTransferTokenSample';
 import CancelTransferTokenSample from '../../src/sample/CancelTransferTokenSample';
+import TestUtil from '../TestUtil';
 
 describe('CancelTransferTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/CreateAndEndorseAccessTokenSample.spec.js
+++ b/test/sample/CreateAndEndorseAccessTokenSample.spec.js
@@ -6,11 +6,16 @@ import 'babel-regenerator-runtime';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import CreateAndEndorseAccessTokenSample from '../../src/sample/CreateAndEndorseAccessTokenSample';
+import TestUtil from '../TestUtil';
 
 describe('CreateAndEndorseAccessTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();

--- a/test/sample/CreateAndEndorseTransferTokenSample.spec.js
+++ b/test/sample/CreateAndEndorseTransferTokenSample.spec.js
@@ -11,11 +11,16 @@ import CreateTransferTokenWithUnusualOptionsSample
   from '../../src/sample/CreateTransferTokenWithUnusualOptionsSample';
 import CreateTransferTokenToDestinationSample
   from '../../src/sample/CreateTransferTokenToDestinationSample';
+import TestUtil from '../TestUtil';
 
 describe('CreateAndEndorseTransferTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
@@ -29,6 +34,10 @@ describe('CreateTransferTokenWithUnusualOptionsSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
@@ -41,6 +50,10 @@ describe('CreateTransferTokenToDestinationSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         const member2Alias = await member2.firstAlias();
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);

--- a/test/sample/CreateAndEndorseTransferTokenSampleWithAttachment.spec.js
+++ b/test/sample/CreateAndEndorseTransferTokenSampleWithAttachment.spec.js
@@ -9,11 +9,16 @@ import CreateAndEndorseTransferTokenWithAttachmentSample
 from '../../src/sample/CreateAndEndorseTransferTokenWithAttachmentSample';
 import CreateTransferTokenAttachSample
 from '../../src/sample/CreateTransferTokenAttachSample';
+import TestUtil from '../TestUtil';
 
 describe('CreateAndEndorseTransferTokenWithAttachmentSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
@@ -28,6 +33,10 @@ describe('CreateTransferTokenAttachSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/DeleteMemberSample.spec.js
+++ b/test/sample/DeleteMemberSample.spec.js
@@ -5,10 +5,14 @@ const assert = chai.assert;
 import 'babel-regenerator-runtime';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import DeleteMemberSample from '../../src/sample/DeleteMemberSample';
+import TestUtil from '../TestUtil';
 
 describe('DeleteMemberSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+        });
         await member.aliases();
         await DeleteMemberSample(member);
         try {

--- a/test/sample/GetAccessTokensSample.spec.js
+++ b/test/sample/GetAccessTokensSample.spec.js
@@ -13,6 +13,10 @@ describe('GetAccessTokensSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async() => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();

--- a/test/sample/GetTransactionSample.spec.js
+++ b/test/sample/GetTransactionSample.spec.js
@@ -9,11 +9,16 @@ import CreateAndEndorseTransferTokenSample
     from '../../src/sample/CreateAndEndorseTransferTokenSample';
 import RedeemTransferTokenSample from '../../src/sample/RedeemTransferTokenSample';
 import GetTransactionSample from '../../src/sample/GetTransactionSample';
+import TestUtil from '../TestUtil';
 
 describe('GetTransactionSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/GetTransactionsSample.spec.js
+++ b/test/sample/GetTransactionsSample.spec.js
@@ -9,11 +9,16 @@ import CreateAndEndorseTransferTokenSample
     from '../../src/sample/CreateAndEndorseTransferTokenSample';
 import RedeemTransferTokenSample from '../../src/sample/RedeemTransferTokenSample';
 import GetTransactionsSample from '../../src/sample/GetTransactionsSample';
+import TestUtil from '../TestUtil';
 
 describe('GetTransactionsSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async() => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/GetTransferTokenAttachmentsSample.spec.js
+++ b/test/sample/GetTransferTokenAttachmentsSample.spec.js
@@ -8,11 +8,16 @@ import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import CreateAndEndorseTransferTokenWithAttachmentSample
     from '../../src/sample/CreateAndEndorseTransferTokenWithAttachmentSample';
 import GetTransferTokenAttachmentsSample from '../../src/sample/GetTransferTokenAttachmentsSample';
+import TestUtil from '../TestUtil';
 
 describe('GetTransferTokenAttachmentsSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async() => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/GetTransfersSample.spec.js
+++ b/test/sample/GetTransfersSample.spec.js
@@ -17,6 +17,10 @@ describe('GetTransfersSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
@@ -34,6 +38,10 @@ describe('GetTransferSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 
@@ -49,6 +57,10 @@ describe('GetTransferTokensSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/MemberMethodsSample.spec.js
+++ b/test/sample/MemberMethodsSample.spec.js
@@ -5,6 +5,7 @@ const assert = chai.assert;
 import 'babel-regenerator-runtime';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import MemberMethodsSample from '../../src/sample/MemberMethodsSample';
+import TestUtil from '../TestUtil';
 
 describe('MemberMethods test', () => {
     it('Should run the aliases sample', async () => {
@@ -13,10 +14,15 @@ describe('MemberMethods test', () => {
         const Token = new TokenLib(TEST_ENV, devKey);
 
         const member = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+        });
         await MemberMethodsSample.aliases(Token, member);
-        const aliases = await member.aliases();
-        assert.equal(aliases.length, 1);
-        assert.isTrue(aliases[0].value.includes('alias4'));
+        await TestUtil.waitUntil(async () => {
+            const aliases = await member.aliases();
+            assert.equal(aliases.length, 1);
+            assert.isTrue(aliases[0].value.includes('alias4'));
+        });
     });
 
     it('Should run the keys sample', async () => {

--- a/test/sample/NotificationsSample.spec.js
+++ b/test/sample/NotificationsSample.spec.js
@@ -1,13 +1,21 @@
 /* eslint-disable new-cap */
+const chai = require('chai');
+const assert = chai.assert;
+
 import 'babel-regenerator-runtime';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import PollNotificationsSample from '../../src/sample/PollNotificationsSample';
+import TestUtil from '../TestUtil';
 
 describe('NotificationsSample test', () => {
     it('PollNotificationsSample should run', async () => {
         const payer = await CreateMemberSample();
         const payee = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await payer.firstAlias());
+            assert.isOk(await payee.firstAlias());
+        });
         await PollNotificationsSample.subscribeMember(payee);
         const auth = await payer.createTestBankAccount(200, 'EUR');
         const accounts = await payer.linkAccounts(auth);

--- a/test/sample/NotifyPaymentRequestSample.spec.js
+++ b/test/sample/NotifyPaymentRequestSample.spec.js
@@ -6,6 +6,7 @@ import 'babel-regenerator-runtime';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import NotifyPaymentRequestSample from '../../src/sample/NotifyPaymentRequestSample';
+import TestUtil from '../TestUtil';
 
 describe('NotifyPaymentRequestSample test', () => {
     it('Should run the sample', async () => {
@@ -15,6 +16,10 @@ describe('NotifyPaymentRequestSample test', () => {
 
         const payee = await CreateMemberSample();
         const payer = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await payee.firstAlias());
+            assert.isOk(await payer.firstAlias());
+        });
         await LinkMemberAndBankSample(payee);
         await LinkMemberAndBankSample(payer);
 

--- a/test/sample/ProvisionDeviceSample.spec.js
+++ b/test/sample/ProvisionDeviceSample.spec.js
@@ -5,11 +5,15 @@ const assert = chai.assert;
 import 'babel-regenerator-runtime';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import ProvisionDeviceSample from '../../src/sample/ProvisionDeviceSample';
+import TestUtil from '../TestUtil';
 
 describe('ProvisionDeviceSample test', () => {
     if (!BROWSER) {
         it('ProvisionDeviceSample should run', async () => {
             const member = await CreateMemberSample();
+            await TestUtil.waitUntil(async () => {
+                assert.isOk(await member.firstAlias());
+            });
             await member.subscribeToNotifications("iron");
             const alias = await member.firstAlias();
 

--- a/test/sample/RedeemAccessTokenSample.spec.js
+++ b/test/sample/RedeemAccessTokenSample.spec.js
@@ -7,11 +7,16 @@ import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import CreateAndEndorseAccessTokenSample from '../../src/sample/CreateAndEndorseAccessTokenSample';
 import RedeemAccessTokenSample from '../../src/sample/RedeemAccessTokenSample';
+import TestUtil from '../TestUtil';
 
 describe('RedeemAccessTokenSample test', () => {
     it('Should run the "use" sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();
@@ -23,12 +28,18 @@ describe('RedeemAccessTokenSample test', () => {
 
     it('Should run the "careful" sample', async () => {
         const grantor = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await grantor.firstAlias());
+        });
         const auth1 = await grantor.createTestBankAccount(200, 'EUR');
         const auth2 = await grantor.createTestBankAccount(200, 'USD');
         const account1 = (await grantor.linkAccounts(auth1))[0];
         const account2 = (await grantor.linkAccounts(auth2))[0];
 
         const grantee = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await grantee.firstAlias());
+        });
 
         const granteeAlias = await grantee.firstAlias();
         const token1 = await CreateAndEndorseAccessTokenSample(grantor, granteeAlias);

--- a/test/sample/RedeemTransferTokenSample.spec.js
+++ b/test/sample/RedeemTransferTokenSample.spec.js
@@ -8,11 +8,16 @@ import LinkMemberAndBankSample from '../../src/sample/LinkMemberAndBankSample';
 import CreateAndEndorseTransferTokenSample
     from '../../src/sample/CreateAndEndorseTransferTokenSample';
 import RedeemTransferTokenSample from '../../src/sample/RedeemTransferTokenSample';
+import TestUtil from '../TestUtil';
 
 describe('RedeemTransferTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
         await LinkMemberAndBankSample(member2);
 

--- a/test/sample/ReplaceAccessToken.spec.js
+++ b/test/sample/ReplaceAccessToken.spec.js
@@ -14,6 +14,10 @@ describe('ReplaceAccessTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();

--- a/test/sample/ReplaceAndEndorseAccessToken.spec.js
+++ b/test/sample/ReplaceAndEndorseAccessToken.spec.js
@@ -15,6 +15,10 @@ describe('ReplaceAndEndorseAccessTokenSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await member.firstAlias());
+            assert.isOk(await member2.firstAlias());
+        });
         await LinkMemberAndBankSample(member);
 
         const member2Alias = await member2.firstAlias();

--- a/test/sample/TokenRequestUrlSample.spec.js
+++ b/test/sample/TokenRequestUrlSample.spec.js
@@ -7,11 +7,16 @@ import TokenRequestUrlSample from '../../src/sample/TokenRequestUrlSample';
 import CreateMemberSample from '../../src/sample/CreateMemberSample';
 import Crypto from "../../src/security/Crypto";
 import Util from "../../src/Util";
+import TestUtil from '../TestUtil';
 
 describe('TokenRequestUrl test', () => {
     it('Should complete the whole token request URL flow', async () => {
         const grantor = await CreateMemberSample();
         const grantee = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await grantor.firstAlias());
+            assert.isOk(await grantee.firstAlias());
+        });
 
         const requestId = Util.generateNonce();
         const originalState = Util.generateNonce();
@@ -35,6 +40,10 @@ describe('TokenRequestUrl test', () => {
 
         const grantor = await CreateMemberSample();
         const grantee = await CreateMemberSample();
+        await TestUtil.waitUntil(async () => {
+            assert.isOk(await grantor.firstAlias());
+            assert.isOk(await grantee.firstAlias());
+        });
         const token = await TokenRequestUrlSample.generateValidAccessToken(grantor, grantee);
 
         const signature = await grantor.signTokenRequestState(token.id, state);


### PR DESCRIPTION
Member service switches to async alias verification processing (see https://github.com/tokenio/member/pull/104/). Adjusted tests to work with it correctly.