### PR TITLE
Fix assigning to err.message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-io",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "",
   "main": "dist/token-io.min.js",
   "scripts": {

--- a/src/Util.js
+++ b/src/Util.js
@@ -115,7 +115,7 @@ class Util {
             const reason = (err.response !== undefined && err.response.data !== undefined) ?
                 err.response.data :
                 "UNKNOWN";
-            err.message = method.name + ': ' + err.message + '. Reason: ' + reason;
+            err.info = method.name + ': ' + err.message + '. Reason: ' + reason;
             return Promise.reject(err);
         }
     }
@@ -134,7 +134,7 @@ class Util {
             const reason = (err.response !== undefined && err.response.data !== undefined) ?
                 err.response.data :
                 "UNKNOWN";
-            err.message = method.name + ': ' + err.message + '. Reason: ' + reason;
+            err.info = method.name + ': ' + err.message + '. Reason: ' + reason;
             throw err;
         }
     }

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -846,10 +846,13 @@ export default class Member {
         return Util.callAsync(this.redeemToken, async () => {
             const finalToken = await this._resolveToken(token);
             if (amount === undefined) {
-                amount = finalToken.payload.transfer.amount;
+                amount = finalToken.payload.transfer.lifetimeAmount;
             }
             if (currency === undefined) {
                 currency = finalToken.payload.transfer.currency;
+            }
+            if (description === undefined) {
+                description = finalToken.payload.description;
             }
             if (Util.countDecimals(amount) > config.decimalPrecision) {
                 throw new Error(

--- a/test/sample/CancelTransferTokenBlockingSample.browserspec.js
+++ b/test/sample/CancelTransferTokenBlockingSample.browserspec.js
@@ -15,7 +15,8 @@ describe('CancelTransferTokenBlockingSample test', () => {
     it('Should run the sample', async () => {
         const member = await CreateMemberSample();
         const member2 = await CreateMemberSample();
-        TestUtil.waitUntil(async () => {
+
+        await TestUtil.waitUntil(async () => {
             assert.isOk(await member.firstAlias());
             assert.isOk(await member2.firstAlias());
         });

--- a/test/sample/DeleteMemberSample.spec.js
+++ b/test/sample/DeleteMemberSample.spec.js
@@ -18,7 +18,7 @@ describe('DeleteMemberSample test', () => {
         try {
             await member.aliases();
         } catch (err) {
-            assert.include(err.message, BROWSER ? "UNKNOWN" : "MEMBER_ID_NOT_FOUND");
+            assert.include(err.info, BROWSER ? "UNKNOWN" : "MEMBER_ID_NOT_FOUND");
         }
     });
 });


### PR DESCRIPTION
`err.message` is readonly so sometimes it will throw an invalid assign error which masks the real error.