### PR TITLE
Update for proto 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "rollup-plugin-json": "^3.0.0",
         "rollup-plugin-node-resolve": "^3.3.0",
         "rollup-plugin-replace": "^2.0.0",
-        "rollup-plugin-uglify": "^4.0.0",
+        "rollup-plugin-uglify": "^5.0.2",
         "webpack": "^4.16.5",
         "webpack-node-externals": "^1.7.2"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "token-io",
-    "version": "2.0.0-beta.3",
+    "version": "2.0.0-beta.4",
     "description": "Token JavaScript SDK",
     "license": "ISC",
     "author": {

--- a/src/Util.js
+++ b/src/Util.js
@@ -143,6 +143,7 @@ class Util {
         if (alias.type === 'USERNAME') {
             return alias.value;
         }
+        alias.realm = undefined; // backend clears realm before hashing
         return bs58.encode(sha256(Buffer.from(stringify(alias), 'utf8')));
     }
 

--- a/src/http/HttpClient.js
+++ b/src/http/HttpClient.js
@@ -68,6 +68,14 @@ class HttpClient {
         return this._instance(request);
     }
 
+    normalizeAlias(alias) {
+        const request = {
+            method: 'get',
+            url: `/aliases/normalize/${alias.type}/${alias.value}/${alias.realm || 'token'}`,
+        };
+        return this._instance(request);
+    }
+
     /**
      * Gets a member given an alias.
      *

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -197,7 +197,8 @@ export default class Member {
     addAlias(alias: Alias): Promise<void> {
         return Util.callAsync(this.addAlias, async () => {
             const prevHash = await this._getPreviousHash();
-            await this._client.addAlias(prevHash, alias.toJSON());
+            const normalizedAlias = this._unauthenticatedClient.normalizeAlias(alias.toJSON());
+            await this._client.addAlias(prevHash, normalizedAlias.toJSON());
         });
     }
 

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -197,8 +197,8 @@ export default class Member {
     addAlias(alias: Alias): Promise<void> {
         return Util.callAsync(this.addAlias, async () => {
             const prevHash = await this._getPreviousHash();
-            const normalizedAlias = this._unauthenticatedClient.normalizeAlias(alias.toJSON());
-            await this._client.addAlias(prevHash, normalizedAlias.toJSON());
+            const res = await this._unauthenticatedClient.normalizeAlias(alias.toJSON());
+            await this._client.addAlias(prevHash, res.data.alias);
         });
     }
 

--- a/src/main/TokenIO.js
+++ b/src/main/TokenIO.js
@@ -129,7 +129,20 @@ export class TokenIO {
     aliasExists(alias: Alias): Promise<boolean> {
         return Util.callAsync(this.aliasExists, async () => {
             const res = await this._unauthenticatedClient.resolveAlias(alias.toJSON());
-            return !!res.data?.member?.id;
+            return !!res.data.member?.id;
+        });
+    }
+
+    /**
+     * Normalizes an alias, you probably won't need to call this as this is automatically called before addAlias()
+     *
+     * @param alias - alias to normalize
+     * @returns normalized alias
+     */
+    normalizeAlias(alias: Alias): Promise<Alias> {
+        return Util.callAsync(this.normalizeAlias, async () => {
+            const res = await this._unauthenticatedClient.normalizeAlias(alias.toJSON());
+            return Alias.create(res.data.alias);
         });
     }
 

--- a/src/proto/gen/proto.js
+++ b/src/proto/gen/proto.js
@@ -110,59 +110,6 @@ export const io = $root.io = (() => {
                         return PlaintextBankAuthorization;
                     })();
 
-                    account.AccountTag = (function() {
-
-                        function AccountTag(p) {
-                            if (p)
-                                for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
-                                    if (p[ks[i]] != null)
-                                        this[ks[i]] = p[ks[i]];
-                        }
-
-                        AccountTag.prototype.key = "";
-                        AccountTag.prototype.value = "";
-
-                        AccountTag.create = function create(properties) {
-                            return new AccountTag(properties);
-                        };
-
-                        AccountTag.fromObject = function fromObject(d) {
-                            if (d instanceof $root.io.token.proto.common.account.AccountTag)
-                                return d;
-                            var m = new $root.io.token.proto.common.account.AccountTag();
-                            if (d.key != null) {
-                                m.key = String(d.key);
-                            }
-                            if (d.value != null) {
-                                m.value = String(d.value);
-                            }
-                            return m;
-                        };
-
-                        AccountTag.toObject = function toObject(m, o) {
-                            if (!o)
-                                o = {};
-                            var d = {};
-                            if (o.defaults) {
-                                d.key = "";
-                                d.value = "";
-                            }
-                            if (m.key != null && m.hasOwnProperty("key")) {
-                                d.key = m.key;
-                            }
-                            if (m.value != null && m.hasOwnProperty("value")) {
-                                d.value = m.value;
-                            }
-                            return d;
-                        };
-
-                        AccountTag.prototype.toJSON = function toJSON() {
-                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                        };
-
-                        return AccountTag;
-                    })();
-
                     account.AccountFeatures = (function() {
 
                         function AccountFeatures(p) {
@@ -240,10 +187,119 @@ export const io = $root.io = (() => {
                         return AccountFeatures;
                     })();
 
+                    account.AccountDetails = (function() {
+
+                        function AccountDetails(p) {
+                            this.metadata = {};
+                            if (p)
+                                for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                                    if (p[ks[i]] != null)
+                                        this[ks[i]] = p[ks[i]];
+                        }
+
+                        AccountDetails.prototype.identifier = "";
+                        AccountDetails.prototype.type = 0;
+                        AccountDetails.prototype.status = "";
+                        AccountDetails.prototype.metadata = $util.emptyObject;
+
+                        AccountDetails.create = function create(properties) {
+                            return new AccountDetails(properties);
+                        };
+
+                        AccountDetails.fromObject = function fromObject(d) {
+                            if (d instanceof $root.io.token.proto.common.account.AccountDetails)
+                                return d;
+                            var m = new $root.io.token.proto.common.account.AccountDetails();
+                            if (d.identifier != null) {
+                                m.identifier = String(d.identifier);
+                            }
+                            switch (d.type) {
+                            case "INVALID":
+                            case 0:
+                                m.type = 0;
+                                break;
+                            case "OTHER":
+                            case 1:
+                                m.type = 1;
+                                break;
+                            case "CHECKING":
+                            case 2:
+                                m.type = 2;
+                                break;
+                            case "SAVINGS":
+                            case 3:
+                                m.type = 3;
+                                break;
+                            case "LOAN":
+                            case 4:
+                                m.type = 4;
+                                break;
+                            }
+                            if (d.status != null) {
+                                m.status = String(d.status);
+                            }
+                            if (d.metadata) {
+                                if (typeof d.metadata !== "object")
+                                    throw TypeError(".io.token.proto.common.account.AccountDetails.metadata: object expected");
+                                m.metadata = {};
+                                for (var ks = Object.keys(d.metadata), i = 0; i < ks.length; ++i) {
+                                    m.metadata[ks[i]] = String(d.metadata[ks[i]]);
+                                }
+                            }
+                            return m;
+                        };
+
+                        AccountDetails.toObject = function toObject(m, o) {
+                            if (!o)
+                                o = {};
+                            var d = {};
+                            if (o.objects || o.defaults) {
+                                d.metadata = {};
+                            }
+                            if (o.defaults) {
+                                d.identifier = "";
+                                d.type = o.enums === String ? "INVALID" : 0;
+                                d.status = "";
+                            }
+                            if (m.identifier != null && m.hasOwnProperty("identifier")) {
+                                d.identifier = m.identifier;
+                            }
+                            if (m.type != null && m.hasOwnProperty("type")) {
+                                d.type = o.enums === String ? $root.io.token.proto.common.account.AccountDetails.AccountType[m.type] : m.type;
+                            }
+                            if (m.status != null && m.hasOwnProperty("status")) {
+                                d.status = m.status;
+                            }
+                            var ks2;
+                            if (m.metadata && (ks2 = Object.keys(m.metadata)).length) {
+                                d.metadata = {};
+                                for (var j = 0; j < ks2.length; ++j) {
+                                    d.metadata[ks2[j]] = m.metadata[ks2[j]];
+                                }
+                            }
+                            return d;
+                        };
+
+                        AccountDetails.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+
+                        AccountDetails.AccountType = (function() {
+                            const valuesById = {}, values = Object.create(valuesById);
+                            values[valuesById[0] = "INVALID"] = 0;
+                            values[valuesById[1] = "OTHER"] = 1;
+                            values[valuesById[2] = "CHECKING"] = 2;
+                            values[valuesById[3] = "SAVINGS"] = 3;
+                            values[valuesById[4] = "LOAN"] = 4;
+                            return values;
+                        })();
+
+                        return AccountDetails;
+                    })();
+
                     account.Account = (function() {
 
                         function Account(p) {
-                            this.tags = [];
                             if (p)
                                 for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
                                     if (p[ks[i]] != null)
@@ -253,11 +309,11 @@ export const io = $root.io = (() => {
                         Account.prototype.id = "";
                         Account.prototype.name = "";
                         Account.prototype.bankId = "";
-                        Account.prototype.tags = $util.emptyArray;
                         Account.prototype.isLocked = false;
                         Account.prototype.accountFeatures = null;
                         Account.prototype.lastCacheUpdateMs = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
                         Account.prototype.nextCacheUpdateMs = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+                        Account.prototype.accountDetails = null;
 
                         Account.create = function create(properties) {
                             return new Account(properties);
@@ -275,16 +331,6 @@ export const io = $root.io = (() => {
                             }
                             if (d.bankId != null) {
                                 m.bankId = String(d.bankId);
-                            }
-                            if (d.tags) {
-                                if (!Array.isArray(d.tags))
-                                    throw TypeError(".io.token.proto.common.account.Account.tags: array expected");
-                                m.tags = [];
-                                for (var i = 0; i < d.tags.length; ++i) {
-                                    if (typeof d.tags[i] !== "object")
-                                        throw TypeError(".io.token.proto.common.account.Account.tags: object expected");
-                                    m.tags[i] = $root.io.token.proto.common.account.AccountTag.fromObject(d.tags[i]);
-                                }
                             }
                             if (d.isLocked != null) {
                                 m.isLocked = Boolean(d.isLocked);
@@ -314,6 +360,11 @@ export const io = $root.io = (() => {
                                 else if (typeof d.nextCacheUpdateMs === "object")
                                     m.nextCacheUpdateMs = new $util.LongBits(d.nextCacheUpdateMs.low >>> 0, d.nextCacheUpdateMs.high >>> 0).toNumber();
                             }
+                            if (d.accountDetails != null) {
+                                if (typeof d.accountDetails !== "object")
+                                    throw TypeError(".io.token.proto.common.account.Account.accountDetails: object expected");
+                                m.accountDetails = $root.io.token.proto.common.account.AccountDetails.fromObject(d.accountDetails);
+                            }
                             return m;
                         };
 
@@ -321,9 +372,6 @@ export const io = $root.io = (() => {
                             if (!o)
                                 o = {};
                             var d = {};
-                            if (o.arrays || o.defaults) {
-                                d.tags = [];
-                            }
                             if (o.defaults) {
                                 d.id = "";
                                 d.name = "";
@@ -340,6 +388,7 @@ export const io = $root.io = (() => {
                                     d.nextCacheUpdateMs = o.longs === String ? n.toString() : o.longs === Number ? n.toNumber() : n;
                                 } else
                                     d.nextCacheUpdateMs = o.longs === String ? "0" : 0;
+                                d.accountDetails = null;
                             }
                             if (m.id != null && m.hasOwnProperty("id")) {
                                 d.id = m.id;
@@ -349,12 +398,6 @@ export const io = $root.io = (() => {
                             }
                             if (m.bankId != null && m.hasOwnProperty("bankId")) {
                                 d.bankId = m.bankId;
-                            }
-                            if (m.tags && m.tags.length) {
-                                d.tags = [];
-                                for (var j = 0; j < m.tags.length; ++j) {
-                                    d.tags[j] = $root.io.token.proto.common.account.AccountTag.toObject(m.tags[j], o);
-                                }
                             }
                             if (m.isLocked != null && m.hasOwnProperty("isLocked")) {
                                 d.isLocked = m.isLocked;
@@ -373,6 +416,9 @@ export const io = $root.io = (() => {
                                     d.nextCacheUpdateMs = o.longs === String ? String(m.nextCacheUpdateMs) : m.nextCacheUpdateMs;
                                 else
                                     d.nextCacheUpdateMs = o.longs === String ? $util.Long.prototype.toString.call(m.nextCacheUpdateMs) : o.longs === Number ? new $util.LongBits(m.nextCacheUpdateMs.low >>> 0, m.nextCacheUpdateMs.high >>> 0).toNumber() : m.nextCacheUpdateMs;
+                            }
+                            if (m.accountDetails != null && m.hasOwnProperty("accountDetails")) {
+                                d.accountDetails = $root.io.token.proto.common.account.AccountDetails.toObject(m.accountDetails, o);
                             }
                             return d;
                         };
@@ -3248,7 +3294,6 @@ export const io = $root.io = (() => {
                         Member.prototype.lastRecoverySequence = 0;
                         Member.prototype.lastOperationSequence = 0;
                         Member.prototype.type = 0;
-                        Member.prototype.tppId = "";
 
                         Member.create = function create(properties) {
                             return new Member(properties);
@@ -3323,9 +3368,6 @@ export const io = $root.io = (() => {
                                 m.type = 4;
                                 break;
                             }
-                            if (d.tppId != null) {
-                                m.tppId = String(d.tppId);
-                            }
                             return m;
                         };
 
@@ -3345,7 +3387,6 @@ export const io = $root.io = (() => {
                                 d.lastRecoverySequence = 0;
                                 d.lastOperationSequence = 0;
                                 d.type = o.enums === String ? "INVALID_MEMBER_TYPE" : 0;
-                                d.tppId = "";
                             }
                             if (m.id != null && m.hasOwnProperty("id")) {
                                 d.id = m.id;
@@ -3382,9 +3423,6 @@ export const io = $root.io = (() => {
                             }
                             if (m.type != null && m.hasOwnProperty("type")) {
                                 d.type = o.enums === String ? $root.io.token.proto.common.member.Member.MemberType[m.type] : m.type;
-                            }
-                            if (m.tppId != null && m.hasOwnProperty("tppId")) {
-                                d.tppId = m.tppId;
                             }
                             return d;
                         };
@@ -5242,6 +5280,7 @@ export const io = $root.io = (() => {
                         TokenRequest.prototype.id = "";
                         TokenRequest.prototype.payload = null;
                         TokenRequest.prototype.options = $util.emptyObject;
+                        TokenRequest.prototype.userRefId = "";
 
                         TokenRequest.create = function create(properties) {
                             return new TokenRequest(properties);
@@ -5267,6 +5306,9 @@ export const io = $root.io = (() => {
                                     m.options[ks[i]] = String(d.options[ks[i]]);
                                 }
                             }
+                            if (d.userRefId != null) {
+                                m.userRefId = String(d.userRefId);
+                            }
                             return m;
                         };
 
@@ -5280,6 +5322,7 @@ export const io = $root.io = (() => {
                             if (o.defaults) {
                                 d.id = "";
                                 d.payload = null;
+                                d.userRefId = "";
                             }
                             if (m.id != null && m.hasOwnProperty("id")) {
                                 d.id = m.id;
@@ -5293,6 +5336,9 @@ export const io = $root.io = (() => {
                                 for (var j = 0; j < ks2.length; ++j) {
                                     d.options[ks2[j]] = m.options[ks2[j]];
                                 }
+                            }
+                            if (m.userRefId != null && m.hasOwnProperty("userRefId")) {
+                                d.userRefId = m.userRefId;
                             }
                             return d;
                         };

--- a/src/proto/index.js.flow
+++ b/src/proto/index.js.flow
@@ -81,16 +81,21 @@ declare export class Address {
     }): Address;
     toJSON(): Object;
 }
+type AccountDetails = {
+    identifier: string;
+    type: 'INVALID' | 'OTHER' | 'CHECKING' | 'SAVINGS' | 'LOAN';
+    status: string;
+    metadata: Object;
+}
 declare export class Account {
     id: string;
     name: string;
     bankId: string;
-    tags: Array<any>;
     isLocked: boolean;
     accountFeatures: any;
     lastCacheUpdateMs: string;
     nextCacheUpdateMs: string;
-    accountDetails: any;
+    accountDetails: ?AccountDetails;
     static create({
         id: string,
         name: string,
@@ -100,7 +105,7 @@ declare export class Account {
         accountFeatures: any,
         lastCacheUpdateMs: string,
         nextCacheUpdateMs: string,
-        accountDetails?: any,
+        accountDetails?: AccountDetails,
     }): Account;
     toJSON(): Object;
 }
@@ -196,7 +201,7 @@ type ResourceTypes = {
 };
 declare export class Resource {
     resource: $Values<ResourceTypes>;
-    static create($Values<ResourceTypes>): Resource;
+    static create({resource: $Values<ResourceTypes>}): Resource;
     toJSON(): Object;
 }
 declare export class Notification {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.47":
+"@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
   dependencies:
@@ -1365,8 +1365,8 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -3418,6 +3418,12 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
+  dependencies:
+    merge-stream "^1.0.1"
+
 js-levenshtein@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.3.tgz#3ef627df48ec8cf24bacf05c0f184ff30ef413c5"
@@ -3836,6 +3842,12 @@ memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   dependencies:
     errno "^0.1.3"
+    readable-stream "^2.0.1"
+
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
     readable-stream "^2.0.1"
 
 micromatch@^2.3.11:
@@ -4959,12 +4971,13 @@ rollup-plugin-replace@^2.0.0:
     minimatch "^3.0.2"
     rollup-pluginutils "^2.0.1"
 
-rollup-plugin-uglify@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-4.0.0.tgz#6eb471738f1ce9ba7d9d4bc43b71cba02417c8fb"
+rollup-plugin-uglify@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-5.0.2.tgz#3d7985faa9760a933eb451fcfb7f54bf76c0651d"
   dependencies:
-    "@babel/code-frame" "^7.0.0-beta.47"
-    uglify-js "^3.3.25"
+    "@babel/code-frame" "^7.0.0"
+    jest-worker "^23.2.0"
+    uglify-js "^3.4.8"
 
 rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.2.0, rollup-pluginutils@^2.3.0:
   version "2.3.1"
@@ -5596,7 +5609,7 @@ uglify-es@^3.3.4:
     commander "~2.13.0"
     source-map "~0.6.1"
 
-uglify-js@^3.3.25:
+uglify-js@^3.4.8:
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.8.tgz#d590777b208258b54131b1ae45bc9d3f68033a3e"
   dependencies:


### PR DESCRIPTION
 - `Account` class now contains optional field `AccountDetails`
 - `normalizeAlias()` called before `addAlias()`