### PR TITLE
RD-1071: Populate realm for affiliated TPPs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "url": "git://github.com/tokenio/sdk-js.git"
     },
     "config": {
-        "proto": "1.1.13"
+        "proto": "1.1.15"
     },
     "scripts": {
         "type": "flow check",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "token-io",
-    "version": "2.0.0-beta.10",
+    "version": "2.0.0-beta.11",
     "description": "Token JavaScript SDK",
     "license": "ISC",
     "author": {

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -199,11 +199,7 @@ export default class Member {
      * @return {Promise} empty - empty promise
      */
     addAlias(alias: Alias): Promise<void> {
-        return Util.callAsync(this.addAlias, async () => {
-            const prevHash = await this._getPreviousHash();
-            const res = await this._unauthenticatedClient.normalizeAlias(alias.toJSON());
-            await this._client.addAlias(prevHash, res.data.alias);
-        });
+        return this.addAliases([alias]);
     }
 
     /**
@@ -214,8 +210,11 @@ export default class Member {
      */
     addAliases(aliases: Array<Alias>): Promise<void> {
         return Util.callAsync(this.addAliases, async () => {
+            const member = await this._getMember();
+            const normalized = await Promise.all(aliases.map(alias =>
+                this._normalizeAlias(alias, member.partnerId)));
             const prevHash = await this._getPreviousHash();
-            await this._client.addAliases(prevHash, aliases.map(a => a.toJSON()));
+            await this._client.addAliases(prevHash, normalized);
         });
     }
 
@@ -1265,6 +1264,22 @@ export default class Member {
             } else {
                 resolve(token);       // Token, already in json representation
             }
+        });
+    }
+
+    _normalizeAlias(alias: Alias, partnerId: string): Promise<Alias> {
+        return Util.callAsync(this._normalizeAlias, async () => {
+            const normalized =
+                (await this._unauthenticatedClient.normalizeAlias(alias.toJSON())).data.alias;
+
+            if (partnerId && partnerId !== 'token') {
+                // Realm must equal member's partner ID if affiliated
+                if (normalized.realm && normalized.realm !== partnerId) {
+                    throw new Error('Alias realm must equal partner ID: ' + partnerId);
+                }
+                normalized.realm = partnerId;
+            }
+            return normalized;
         });
     }
 }

--- a/src/proto/gen/proto.js
+++ b/src/proto/gen/proto.js
@@ -2791,6 +2791,36 @@ export const io = $root.io = (() => {
                         return MemberDeleteOperation;
                     })();
 
+                    member.MemberPartnerOperation = (function() {
+
+                        function MemberPartnerOperation(p) {
+                            if (p)
+                                for (var ks = Object.keys(p), i = 0; i < ks.length; ++i)
+                                    if (p[ks[i]] != null)
+                                        this[ks[i]] = p[ks[i]];
+                        }
+
+                        MemberPartnerOperation.create = function create(properties) {
+                            return new MemberPartnerOperation(properties);
+                        };
+
+                        MemberPartnerOperation.fromObject = function fromObject(d) {
+                            if (d instanceof $root.io.token.proto.common.member.MemberPartnerOperation)
+                                return d;
+                            return new $root.io.token.proto.common.member.MemberPartnerOperation();
+                        };
+
+                        MemberPartnerOperation.toObject = function toObject() {
+                            return {};
+                        };
+
+                        MemberPartnerOperation.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+
+                        return MemberPartnerOperation;
+                    })();
+
                     member.MemberOperation = (function() {
 
                         function MemberOperation(p) {
@@ -2808,11 +2838,13 @@ export const io = $root.io = (() => {
                         MemberOperation.prototype.recoveryRules = null;
                         MemberOperation.prototype.recover = null;
                         MemberOperation.prototype["delete"] = null;
+                        MemberOperation.prototype.verifyPartner = null;
+                        MemberOperation.prototype.unverifyPartner = null;
 
                         let $oneOfFields;
 
                         Object.defineProperty(MemberOperation.prototype, "operation", {
-                            get: $util.oneOfGetter($oneOfFields = ["addKey", "removeKey", "removeAlias", "addAlias", "verifyAlias", "recoveryRules", "recover", "delete"]),
+                            get: $util.oneOfGetter($oneOfFields = ["addKey", "removeKey", "removeAlias", "addAlias", "verifyAlias", "recoveryRules", "recover", "delete", "verifyPartner", "unverifyPartner"]),
                             set: $util.oneOfSetter($oneOfFields)
                         });
 
@@ -2864,6 +2896,16 @@ export const io = $root.io = (() => {
                                     throw TypeError(".io.token.proto.common.member.MemberOperation.delete: object expected");
                                 m["delete"] = $root.io.token.proto.common.member.MemberDeleteOperation.fromObject(d["delete"]);
                             }
+                            if (d.verifyPartner != null) {
+                                if (typeof d.verifyPartner !== "object")
+                                    throw TypeError(".io.token.proto.common.member.MemberOperation.verifyPartner: object expected");
+                                m.verifyPartner = $root.io.token.proto.common.member.MemberPartnerOperation.fromObject(d.verifyPartner);
+                            }
+                            if (d.unverifyPartner != null) {
+                                if (typeof d.unverifyPartner !== "object")
+                                    throw TypeError(".io.token.proto.common.member.MemberOperation.unverifyPartner: object expected");
+                                m.unverifyPartner = $root.io.token.proto.common.member.MemberPartnerOperation.fromObject(d.unverifyPartner);
+                            }
                             return m;
                         };
 
@@ -2910,6 +2952,16 @@ export const io = $root.io = (() => {
                                 d["delete"] = $root.io.token.proto.common.member.MemberDeleteOperation.toObject(m["delete"], o);
                                 if (o.oneofs)
                                     d.operation = "delete";
+                            }
+                            if (m.verifyPartner != null && m.hasOwnProperty("verifyPartner")) {
+                                d.verifyPartner = $root.io.token.proto.common.member.MemberPartnerOperation.toObject(m.verifyPartner, o);
+                                if (o.oneofs)
+                                    d.operation = "verifyPartner";
+                            }
+                            if (m.unverifyPartner != null && m.hasOwnProperty("unverifyPartner")) {
+                                d.unverifyPartner = $root.io.token.proto.common.member.MemberPartnerOperation.toObject(m.unverifyPartner, o);
+                                if (o.oneofs)
+                                    d.operation = "unverifyPartner";
                             }
                             return d;
                         };
@@ -3294,6 +3346,8 @@ export const io = $root.io = (() => {
                         Member.prototype.lastRecoverySequence = 0;
                         Member.prototype.lastOperationSequence = 0;
                         Member.prototype.type = 0;
+                        Member.prototype.partnerId = "";
+                        Member.prototype.isVerifiedPartner = false;
 
                         Member.create = function create(properties) {
                             return new Member(properties);
@@ -3368,6 +3422,12 @@ export const io = $root.io = (() => {
                                 m.type = 4;
                                 break;
                             }
+                            if (d.partnerId != null) {
+                                m.partnerId = String(d.partnerId);
+                            }
+                            if (d.isVerifiedPartner != null) {
+                                m.isVerifiedPartner = Boolean(d.isVerifiedPartner);
+                            }
                             return m;
                         };
 
@@ -3387,6 +3447,8 @@ export const io = $root.io = (() => {
                                 d.lastRecoverySequence = 0;
                                 d.lastOperationSequence = 0;
                                 d.type = o.enums === String ? "INVALID_MEMBER_TYPE" : 0;
+                                d.partnerId = "";
+                                d.isVerifiedPartner = false;
                             }
                             if (m.id != null && m.hasOwnProperty("id")) {
                                 d.id = m.id;
@@ -3423,6 +3485,12 @@ export const io = $root.io = (() => {
                             }
                             if (m.type != null && m.hasOwnProperty("type")) {
                                 d.type = o.enums === String ? $root.io.token.proto.common.member.Member.MemberType[m.type] : m.type;
+                            }
+                            if (m.partnerId != null && m.hasOwnProperty("partnerId")) {
+                                d.partnerId = m.partnerId;
+                            }
+                            if (m.isVerifiedPartner != null && m.hasOwnProperty("isVerifiedPartner")) {
+                                d.isVerifiedPartner = m.isVerifiedPartner;
                             }
                             return d;
                         };


### PR DESCRIPTION
TPPs who are affiliated with a partner (have partnerId set) can only own realms in the partner's realm (= partnerId).

We automatically populate realm for these TPPs so that users of the SDK don't need to do it themselves.