### PR TITLE
RD-1255: createTestBankAccount returns access token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "token-io",
-    "version": "2.0.0-beta.20",
+    "version": "2.0.0-beta.21",
     "description": "Token JavaScript SDK",
     "license": "ISC",
     "author": {

--- a/src/main/Member.js
+++ b/src/main/Member.js
@@ -1258,7 +1258,6 @@ export default class Member {
     /**
      * Creates a test bank account in a fake bank
      *
-     * @deprecated - use createTestBankAccountOauth
      * @param {double} balance - balance of the account
      * @param {string} currency - currency of the account
      * @return {Array} bank authorization to use with linkAccounts
@@ -1266,16 +1265,17 @@ export default class Member {
     createTestBankAccount(
         balance: number,
         currency: string
-    ): Promise<Array<any>> {
+    ): Promise<OauthBankAuthorization> {
         return Util.callAsync(this.createTestBankAccount, async () => {
             const res = await this._client.createTestBankAccount(balance, currency);
-            return res.data.bankAuthorization;
+            return OauthBankAuthorization.create(res.data.authorization);
         });
     }
 
     /**
      * Creates a test bank account in a fake bank
      *
+     * @deprecated - use createTestBankAccount
      * @param {double} balance - balance of the account
      * @param {string} currency - currency of the account
      * @return {Array} bank authorization to use with linkAccounts
@@ -1289,6 +1289,7 @@ export default class Member {
             return OauthBankAuthorization.create(res.data.authorization);
         });
     }
+
     /**
      * Gets test bank notification.
      *

--- a/src/main/TransferTokenBuilder.js
+++ b/src/main/TransferTokenBuilder.js
@@ -91,23 +91,6 @@ export default class TransferTokenBuilder {
     }
 
     /**
-     * Sets the source bank authorization.
-     *
-     * @param {Object} authorization - bank authorization for source account
-     * @return {TransferTokenBuilder} builder - returns back the builder object
-     */
-    setBankAuthorization(authorization) {
-        this._payload.transfer.instructions.source = {
-            account: {
-                tokenAuthorization: {
-                    authorization,
-                },
-            },
-        };
-        return this;
-    }
-
-    /**
      * Sets the expiration date of the token.
      *
      * @param {number} expiresAtMs - expiration date in milliseconds

--- a/src/sample/LinkMemberAndBankSample.js
+++ b/src/sample/LinkMemberAndBankSample.js
@@ -2,19 +2,13 @@
 /**
  * Links a Token member and a bank.
  *
- * The bank linking is currently only supported by the Token PSD2 IOS mobile app.
- * This sample is implemented for a very high level illustration of the bank linking concept
- * and serves as an integral building block connecting other samples. The desktop version of
- * the bank linking process is in the development. Until it's ready, please use Token PSD2 IOS
- * mobile app to link Token members and banks.
- *
  * @param {Member} member - Token member to link to a bank
  */
 export default async (member) => {
     // Generates a test bank account that we can link with.
-    // Gives us an encrypted BankAuthorization
+    // Gives us an encrypted authorization.
     const auth = await member.createTestBankAccount(200, 'EUR');
 
-    // Links the account by sending the BankAuthorization
+    // Links the account by sending the authorization.
     const accounts = await member.linkAccounts(auth);
 };


### PR DESCRIPTION
It seems the new createTestBankAccountOauth method never caught on, so instead of switching everything to it now, I will just change the return type of createTestBankAccount. It's a nicer name, anyway.

This breaks a bunch of stuff that I will fix in separate PRs. Fortunately, the most common use of createTestBankAccount is to create an authorization that is immediately passed to linkAccounts. This is fortunate because linkAccounts accepts both types of authorization, so nothing will break in these cases.