### PR TITLE
Correction

### DIFF
--- a/new-sdks/tpp/package.json
+++ b/new-sdks/tpp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/tpp",
-    "version": "1.0.0-beta.5",
+    "version": "1.0.0-beta.6",
     "description": "Token JavaScript TPP SDK",
     "license": "ISC",
     "author": {

--- a/new-sdks/tpp/src/main/TokenClient.js
+++ b/new-sdks/tpp/src/main/TokenClient.js
@@ -174,9 +174,9 @@ export class TokenClient extends Core {
         return Util.callAsync(this.parseTokenRequestCallbackParams, async () => {
             const tokenMember = await this._unauthenticatedClient.getTokenMember();
             const params = {
-                tokenId: decodeURIComponent(callback.tokenId),
+                tokenId: callback.tokenId,
                 state: JSON.parse(decodeURIComponent(callback.state)),
-                signature: JSON.parse(decodeURIComponent(callback.signature)),
+                signature: JSON.parse(callback.signature),
             };
 
             if (csrfToken &&
@@ -186,7 +186,7 @@ export class TokenClient extends Core {
             const signingKey = Util.getSigningKey(tokenMember.keys, params.signature);
             await this.Crypto.verifyJson(
                 {
-                    state: encodeURIComponent(JSON.stringify(params.state)),
+                    state: callback.state,
                     tokenId: params.tokenId,
                 },
                 params.signature.signature,

--- a/new-sdks/tpp/src/main/TokenClient.js
+++ b/new-sdks/tpp/src/main/TokenClient.js
@@ -174,9 +174,9 @@ export class TokenClient extends Core {
         return Util.callAsync(this.parseTokenRequestCallbackParams, async () => {
             const tokenMember = await this._unauthenticatedClient.getTokenMember();
             const params = {
-                tokenId: callback.tokenId,
-                state: JSON.parse(callback.state),
-                signature: JSON.parse(callback.signature),
+                tokenId: decodeURIComponent(callback.tokenId),
+                state: JSON.parse(decodeURIComponent(callback.state)),
+                signature: JSON.parse(decodeURIComponent(callback.signature)),
             };
 
             if (csrfToken &&


### PR DESCRIPTION
We do need to decode here because the state is encoded in `storeTokenRequest`. 