### PR TITLE
PLT-930: fix key levels

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/core",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/core",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "description": "Token JavaScript Core SDK",
     "license": "ISC",
     "author": {

--- a/core/src/http/AuthHttpClient.js
+++ b/core/src/http/AuthHttpClient.js
@@ -51,30 +51,30 @@ export class AuthHttpClient {
 
     /**
      * Creates the necessary signer objects, based on the level requested.
-     * If the level is not available, attempts to fetch a lower level.
+     * If the level is not available, attempts to fetch a higher level.
      *
-     * @param {string} level - requested level of key
+     * @param {string} level - requested minimum level of key
      * @return {Promise} object used to sign
      */
     async getSigner(level) {
-        if (level === config.KeyLevel.LOW) {
-            return await this._cryptoEngine.createSigner(config.KeyLevel.LOW);
+        if (level === config.KeyLevel.PRIVILEGED) {
+            return await this._cryptoEngine.createSigner(config.KeyLevel.PRIVILEGED);
         }
         if (level === config.KeyLevel.STANDARD) {
             try {
                 return await this._cryptoEngine.createSigner(config.KeyLevel.STANDARD);
             } catch (err) {
-                return await this._cryptoEngine.createSigner(config.KeyLevel.LOW);
+                return await this._cryptoEngine.createSigner(config.KeyLevel.PRIVILEGED);
             }
         }
-        if (level === config.KeyLevel.PRIVILEGED) {
+        if (level === config.KeyLevel.LOW) {
             try {
-                return await this._cryptoEngine.createSigner(config.KeyLevel.PRIVILEGED);
+                return await this._cryptoEngine.createSigner(config.KeyLevel.LOW);
             } catch (err) {
                 try {
                     return await this._cryptoEngine.createSigner(config.KeyLevel.STANDARD);
                 } catch (err2) {
-                    return await this._cryptoEngine.createSigner(config.KeyLevel.LOW);
+                    return await this._cryptoEngine.createSigner(config.KeyLevel.PRIVILEGED);
                 }
             }
         }

--- a/tpp/package-lock.json
+++ b/tpp/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/tpp",
-    "version": "1.0.42",
+    "version": "1.0.43",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
A PRIVILEGED - not the LOW - level key should be enough for all cases. Right now it looks like a call requiring privileged key can be signed by a low key in case only low one is present.