### PR TITLE
DSH-295 | remove caret

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -38,7 +38,7 @@
         "buffer": "^5.2.1",
         "fast-json-stable-stringify": "^2.0.0",
         "fast-sha256": "^1.1.0",
-        "node-forge": "^0.10.0",
+        "node-forge": "0.10.0",
         "tweetnacl": "^1.0.1"
     }
 }

--- a/tpp/package.json
+++ b/tpp/package.json
@@ -67,7 +67,7 @@
         "buffer": "^5.4.2",
         "fast-json-stable-stringify": "^2.0.0",
         "fast-sha256": "^1.1.0",
-        "node-forge": "^0.10.0",
+        "node-forge": "0.10.0",
         "tweetnacl": "^1.0.1"
     }
 }


### PR DESCRIPTION
other repo's not forcing the update of node-forge due to the caret