### PR TITLE
SRE-2437-extend-env-check

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/app",
-    "version": "1.0.57",
+    "version": "1.0.58",
     "description": "Token JavaScript App SDK",
     "license": "ISC",
     "author": {

--- a/app/src/config.json
+++ b/app/src/config.json
@@ -3,6 +3,7 @@
   "urls": {
     "local": "http://localhost:8000",
     "dev": "https://api.dev.token.io",
+    "dev-eks": "https://api.dev-eks.token.io",
     "stg": "https://api.stg.token.io",
     "perf": "https://api.perf.token.io",
     "sandbox": "https://api.sandbox.token.io",
@@ -14,6 +15,7 @@
   "webAppUrls": {
     "local": "http://localhost:5000",
     "dev": "https://web-app.dev.token.io",
+    "dev-eks": "https://web-app.dev-eks.token.io",
     "stg": "https://web-app.stg.token.io",
     "perf": "https://web-app.perf.token.io",
     "sandbox": "https://web-app.sandbox.token.io",
@@ -36,6 +38,7 @@
   "devKey": {
     "local": "f3982819-5d8d-4123-9601-886df2780f42",
     "dev": "f3982819-5d8d-4123-9601-886df2780f42",
+    "dev-eks": "f3982819-5d8d-4123-9601-886df2780f42",
     "stg": "f3982819-5d8d-4123-9601-886df2780f42",
     "perf": "f3982819-5d8d-4123-9601-886df2780f42",
     "sandbox": "f3982819-5d8d-4123-9601-886df2780f42",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@token-io/core",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "Token JavaScript Core SDK",
   "license": "ISC",
   "author": {

--- a/core/src/config.json
+++ b/core/src/config.json
@@ -3,6 +3,7 @@
   "urls": {
     "local": "http://localhost:8000",
     "dev": "https://api.dev.token.io",
+    "dev-eks": "https://api.dev-eks.token.io",
     "stg": "https://api.stg.token.io",
     "perf": "https://api.perf.token.io",
     "sandbox": "https://api.sandbox.token.io",
@@ -14,6 +15,7 @@
   "webAppUrls": {
     "local": "http://localhost:5000",
     "dev": "https://web-app.dev.token.io",
+    "dev-eks": "https://web-app.dev-eks.token.io",
     "stg": "https://web-app.stg.token.io",
     "perf": "https://web-app.perf.token.io",
     "sandbox": "https://web-app.sandbox.token.io",
@@ -37,6 +39,7 @@
     "default": "f3982819-5d8d-4123-9601-886df2780f42",
     "local": "f3982819-5d8d-4123-9601-886df2780f42",
     "dev": "f3982819-5d8d-4123-9601-886df2780f42",
+    "dev-eks": "f3982819-5d8d-4123-9601-886df2780f42",
     "stg": "f3982819-5d8d-4123-9601-886df2780f42",
     "sandbox": "f3982819-5d8d-4123-9601-886df2780f42",
     "int": "f3982819-5d8d-4123-9601-886df2780f42",

--- a/tpp/package.json
+++ b/tpp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/tpp",
-    "version": "1.0.77",
+    "version": "1.0.78",
     "description": "Token JavaScript TPP SDK",
     "license": "ISC",
     "author": {

--- a/tpp/src/config.json
+++ b/tpp/src/config.json
@@ -3,6 +3,7 @@
   "urls": {
     "local": "http://localhost:8000",
     "dev": "https://api.dev.token.io",
+    "dev-eks": "https://api.dev-eks.token.io",
     "stg": "https://api.stg.token.io",
     "perf": "https://api.perf.token.io",
     "sandbox": "https://api.sandbox.token.io",
@@ -14,6 +15,7 @@
   "webAppUrls": {
     "local": "http://localhost:5000",
     "dev": "https://web-app.dev.token.io",
+    "dev-eks": "https://web-app.dev-eks.token.io",
     "stg": "https://web-app.stg.token.io",
     "perf": "https://web-app.perf.token.io",
     "sandbox": "https://web-app.sandbox.token.io",
@@ -36,6 +38,7 @@
   "devKey": {
     "local": "f3982819-5d8d-4123-9601-886df2780f42",
     "dev": "f3982819-5d8d-4123-9601-886df2780f42",
+    "dev-eks": "f3982819-5d8d-4123-9601-886df2780f42",
     "stg": "f3982819-5d8d-4123-9601-886df2780f42",
     "perf": "f3982819-5d8d-4123-9601-886df2780f42",
     "sandbox": "f3982819-5d8d-4123-9601-886df2780f42",


### PR DESCRIPTION
adding new environment to pass the vaidation check
```
Replacing Token DNS part
55
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
54
Error: Invalid environment string. Please use one of: {"local":"http://localhost:8000","dev":"https://api.dev.token.io","stg":"https://api.stg.token.io","perf":"https://api.perf.token.io","sandbox":"https://api.sandbox.token.io","int":"https://api.int.token.io","prd":"https://api.token.io","beta":"https://api.beta.token.io"}
53
    at new HttpClient (/app/node_modules/@token-io/tpp/dist/tokenio.js:632:13)
52
    at new HttpClient$1 (/app/node_modules/@token-io/tpp/dist/tokenio.js:3309:5)
51
    at new TokenClient$1 (/app/node_modules/@token-io/tpp/dist/tokenio.js:5834:35)
50
    at Object.<anonymous> (/app/server/routes/playground/helper.js:50:18)
49
    at Module._compile (node:internal/modules/cjs/loader:1191:14)
48
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1245:10)
47
    at Module.load (node:internal/modules/cjs/loader:1069:32)
46
    at Function.Module._load (node:internal/modules/cjs/loader:904:12)
45
    at Module.require (node:internal/modules/cjs/loader:1093:19)
44
    at require (node:internal/modules/cjs/helpers:108:18)
43
{
42
  exception: { values: [ [Object] ] },
```