### PR TITLE
PAYENG-629 | add support for custom headers in API requests to the Gateway

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@token-io/core",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@token-io/core",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Token JavaScript Core SDK",
   "license": "ISC",
   "author": {

--- a/core/src/http/HttpClient.js
+++ b/core/src/http/HttpClient.js
@@ -2,6 +2,7 @@ import config from '../config.json';
 import ErrorHandler from './ErrorHandler';
 import DeveloperHeader from './DeveloperHeader';
 import VersionHeader from './VersionHeader';
+import MiscHeaders from './MiscHeaders';
 import setAdditionalHeaders from './setAdditionalHeaders';
 import Util from '../Util';
 import axios from 'axios';
@@ -29,11 +30,14 @@ export class HttpClient {
             Util.setUpHttpErrorLogging(this._instance);
         }
         Util.setUpCustomResponseInterceptor(this._instance, customResponseInterceptor);
+        this._context = { miscHeaders: {} };
         const versionHeader = new VersionHeader();
         const developerHeader = new DeveloperHeader(developerKey);
+        const miscHeaders = new MiscHeaders();
         this._instance.interceptors.request.use(request => {
             versionHeader.addVersionHeader(request);
             developerHeader.addDeveloperHeader(request);
+            miscHeaders.setMiscHeaders(request, this._context);
             setAdditionalHeaders(request);
             return request;
         });
@@ -42,6 +46,22 @@ export class HttpClient {
         this._instance.interceptors.response.use(null, error => {
             throw errorHandler.handleError(error);
         });
+    }
+
+    /**
+     * Sets misc headers to be sent with every request.
+     *
+     * @param {Object} headers - key-value map of headers to merge
+     */
+    setMiscHeaders(headers) {
+        this._context.miscHeaders = {...this._context.miscHeaders, ...headers};
+    }
+
+    /**
+     * Clears all misc headers.
+     */
+    clearMiscHeaders() {
+        this._context.miscHeaders = {};
     }
 
     async normalizeAlias(alias) {

--- a/core/src/http/MiscHeaders.js
+++ b/core/src/http/MiscHeaders.js
@@ -1,3 +1,5 @@
+const ALLOWED_PREFIX = 'x-token-trace-';
+
 /**
  * Class to add misc headers
  */
@@ -14,7 +16,7 @@ class MiscHeaders {
                 config.headers['token-json-error'] = context.miscHeaders.jsonError;
             }
             Object.entries(context.miscHeaders).forEach(([key, value]) => {
-                if (key !== 'jsonError' && value !== undefined) {
+                if (key.startsWith(ALLOWED_PREFIX) && value !== undefined) {
                     config.headers[key] = value;
                 }
             });

--- a/core/src/http/MiscHeaders.js
+++ b/core/src/http/MiscHeaders.js
@@ -13,6 +13,11 @@ class MiscHeaders {
             if (context.miscHeaders.jsonError){
                 config.headers['token-json-error'] = context.miscHeaders.jsonError;
             }
+            Object.entries(context.miscHeaders).forEach(([key, value]) => {
+                if (key !== 'jsonError' && value !== undefined) {
+                    config.headers[key] = value;
+                }
+            });
         }
     }
 }

--- a/core/src/main/TokenClient.js
+++ b/core/src/main/TokenClient.js
@@ -183,4 +183,27 @@ export class TokenClient {
             return res.data.countries;
         });
     }
+
+    /**
+     * Sets custom headers to be sent with every request.
+     * Can be called multiple times to merge additional headers.
+     *
+     * @param headers - key-value map of headers
+     */
+    setCustomHeaders(headers: {[string]: string}): void {
+        this.options.customHeaders = {...(this.options.customHeaders || {}), ...headers};
+        if (this._unauthenticatedClient) {
+            this._unauthenticatedClient.setMiscHeaders(headers);
+        }
+    }
+
+    /**
+     * Clears all custom headers.
+     */
+    clearCustomHeaders(): void {
+        this.options.customHeaders = {};
+        if (this._unauthenticatedClient) {
+            this._unauthenticatedClient.clearMiscHeaders();
+        }
+    }
 }


### PR DESCRIPTION
Adds the ability to set and propagate custom tracing headers across all HTTP clients and members, enabling better observability and request correlation.

Changes
Added setMiscHeaders() and clearMiscHeaders() methods to the base HttpClient class in core, allowing arbitrary headers to be sent with every request

Extended MiscHeaders interceptor to forward all custom key-value header pairs (not just jsonError)

Added setCustomHeaders() and clearCustomHeaders() methods to TokenClient for setting headers at the SDK level and propagating them to underlying HTTP clients