### PR TITLE
[TEK-182] Authenticate GetTokenRequestResult and remove the unauthenticated variant

### DIFF
--- a/tpp/package-lock.json
+++ b/tpp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@token-io/tpp",
-    "version": "1.0.94",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@token-io/tpp",
-            "version": "1.0.94",
+            "version": "2.0.0",
             "license": "ISC",
             "dependencies": {
                 "@babel/runtime-corejs2": "^7.5.5",

--- a/tpp/package.json
+++ b/tpp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/tpp",
-    "version": "1.0.94",
+    "version": "2.0.0",
     "description": "Token JavaScript TPP SDK",
     "license": "ISC",
     "author": {

--- a/tpp/src/http/AuthHttpClient.js
+++ b/tpp/src/http/AuthHttpClient.js
@@ -164,6 +164,20 @@ class AuthHttpClient extends CoreAuthHttpClient {
     }
 
     /**
+     * Gets the token request result based on its token request ID.
+     *
+     * @param {string} tokenRequestId - token request ID
+     * @return {Promise} response to the API call
+     */
+    async getTokenRequestResult(tokenRequestId) {
+        const request = {
+            method: 'get',
+            url: `/token-requests/${tokenRequestId}/token_request_result`,
+        };
+        return this._instance(request);
+    }
+
+    /**
      * Sets destination account for once if it has'nt been set.
      *
      * @param {string} tokenRequestId - tokenRequestId

--- a/tpp/src/http/HttpClient.js
+++ b/tpp/src/http/HttpClient.js
@@ -23,20 +23,6 @@ class HttpClient extends CoreHttpClient{
     }
 
     /**
-     * Get the token request result based on its token request ID.
-     *
-     * @param {string} tokenRequestId - token request ID
-     * @return {Object} response to the API call
-     */
-    async getTokenRequestResult(tokenRequestId) {
-        const request = {
-            method: 'get',
-            url: `/token-requests/${tokenRequestId}/token_request_result`,
-        };
-        return this._instance(request);
-    }
-
-    /**
      * Create and onboard a business member under realm of a bank using eIDAS certificate.
      *
      * @param payload payload with eIDAS certificate and bank id

--- a/tpp/src/main/Member.js
+++ b/tpp/src/main/Member.js
@@ -11,6 +11,7 @@ import type {
     BlobPayload,
     Profile,
     ProfilePictureSize,
+    Signature,
     Token,
     TokenRequest,
     TokenOperationResult,
@@ -235,6 +236,21 @@ export default class Member extends CoreMember {
                 encodeURIComponent(JSON.stringify(tokenRequest.requestPayload.callbackState));
             const res = await this._client.storeTokenRequest(tokenRequest);
             return res.data.tokenRequest;
+        });
+    }
+
+    /**
+     * Gets the token request result based on its token request ID.
+     *
+     * @param tokenRequestId - token request ID
+     * @return token ID, signature, and transfer ID if present
+     */
+    getTokenRequestResult(
+        tokenRequestId: string
+    ): Promise<{tokenId: string, signature: Signature, transferId: string}> {
+        return Util.callAsync(this.getTokenRequestResult, async () => {
+            const res = await this._client.getTokenRequestResult(tokenRequestId);
+            return res.data;
         });
     }
 

--- a/tpp/src/main/TokenClient.js
+++ b/tpp/src/main/TokenClient.js
@@ -12,7 +12,6 @@ import type {
     Alias,
     ResourceType,
     AccountResources,
-    Signature,
     TokenRequest,
     KeyStoreCryptoEngine,
     TokenRequestTransferDestinationsCallbackParameters,
@@ -368,18 +367,4 @@ export class TokenClient extends Core {
         });
     }
 
-    /**
-     * Gets the token request result based on its token request ID.
-     *
-     * @param tokenRequestId - token request ID
-     * @return token ID, signature, and transfer ID if present
-     */
-    getTokenRequestResult(
-        tokenRequestId: string
-    ): Promise<{tokenId: string, signature: Signature, transferId: string}> {
-        return Util.callAsync(this.getTokenRequestResult, async () => {
-            const res = await this._unauthenticatedClient.getTokenRequestResult(tokenRequestId);
-            return res.data;
-        });
-    }
 }

--- a/tpp/test/http/AuthHttpClient.spec.js
+++ b/tpp/test/http/AuthHttpClient.spec.js
@@ -129,6 +129,37 @@ describe('AuthHttpClient', () => {
 });
 
 
+describe('Member getTokenRequestResult', () => {
+    it('should send an authenticated GET to the token request result path', async () => {
+        const memberId = 'm:test:456';
+        const engine = new MemoryCryptoEngine(memberId);
+        await engine.generateKey('LOW');
+        const member = new Member({
+            env: TEST_ENV,
+            memberId,
+            cryptoEngine: engine,
+            developerKey: devKey,
+        });
+        let captured;
+        // stub both clients, so using the unauthenticated one is caught rather than escaping to the network
+        for (const client of [member._client, member._unauthenticatedClient]) {
+            client._instance.defaults.adapter = async config => {
+                captured = config;
+                return {data: {tokenId: 'tk'}, status: 200, statusText: 'OK', headers: {}, config};
+            };
+        }
+
+        await member.getTokenRequestResult('tr:123');
+
+        assert.equal(captured.method, 'get');
+        assert.equal(captured.url, '/token-requests/tr:123/token_request_result');
+        const authorization = captured.headers.get('Authorization');
+        assert.isOk(authorization, 'request was not authenticated');
+        assert.match(authorization, new RegExp(`member-id=${memberId},`));
+        assert.match(authorization, /signature=[^,]+/);
+    });
+});
+
 describe('Member misc headers', () => {
     it('should automatically set member-id header', () => {
         const engine = new MemoryCryptoEngine('m:test:member:456');


### PR DESCRIPTION
> [!WARNING]
> **Unauthenticated `GetTokenRequestResult` is being blocked at the API ([PAYENG-468](https://tokenio.atlassian.net/browse/PAYENG-468)) — callers must move to the authenticated path.**

[TEK-182](https://tokenio.atlassian.net/browse/TEK-182) — adds `Member.getTokenRequestResult`, routed through `AuthHttpClient` so the call is signed, and removes the unauthenticated `TokenClient.getTokenRequestResult`, so `2.0.0`. `@token-io/app` is untouched: a PSU browser is built with `developerKey` only and has no keys to sign with.
Consumers pinned to `^1.0.x` (developer-portal, merchant-demo, aisp-demo) must move to `member.getTokenRequestResult` when they upgrade.


[PAYENG-468]: https://tokenio.atlassian.net/browse/PAYENG-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TEK-182]: https://tokenio.atlassian.net/browse/TEK-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ