### PR TITLE
[PAYENG-461] Add authenticated notifyPaymentRequest to the app Member

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@token-io/app",
-    "version": "1.0.77",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@token-io/app",
-            "version": "1.0.77",
+            "version": "1.1.0",
             "license": "ISC",
             "dependencies": {
                 "@babel/runtime-corejs2": "^7.8.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/app",
-    "version": "1.0.77",
+    "version": "1.1.0",
     "description": "Token JavaScript App SDK",
     "license": "ISC",
     "author": {

--- a/app/sample/NotifyPaymentRequestSample.js
+++ b/app/sample/NotifyPaymentRequestSample.js
@@ -35,6 +35,6 @@ export default async (Token, payee, payerAlias) => {
         // transfer token will have random refId:
         refId: cartId,
     };
-    const status = await Token.notifyPaymentRequest(paymentRequest);
+    const status = await payee.notifyPaymentRequest(paymentRequest);
     return status;
 };

--- a/app/src/http/AuthHttpClient.js
+++ b/app/src/http/AuthHttpClient.js
@@ -13,6 +13,24 @@ class AuthHttpClient extends CoreAuthHttpClient {
     }
 
     /**
+     * Sends a notification to a user to request a payment.
+     *
+     * @param {Object} tokenPayload - requested transfer token
+     * @return {Object} response to the API call
+     */
+    async notifyPaymentRequest(tokenPayload) {
+        const req = {
+            tokenPayload,
+        };
+        const request = {
+            method: 'post',
+            url: '/request-transfer',
+            data: req,
+        };
+        return this._instance(request);
+    }
+
+    /**
      * Subscribes to push notifications.
      *
      * @param {string} handler - who is handling the notifications

--- a/app/src/http/HttpClient.js
+++ b/app/src/http/HttpClient.js
@@ -48,6 +48,7 @@ class HttpClient extends CoreHttpClient{
      *
      * @param {Object} tokenPayload - requested transfer token
      * @return {Object} response to the API call
+     * @deprecated use AuthHttpClient#notifyPaymentRequest instead
      */
     async notifyPaymentRequest(tokenPayload) {
         const req = {

--- a/app/src/main/Member.js
+++ b/app/src/main/Member.js
@@ -13,6 +13,7 @@ import Account from './Account';
 import type {
     Blob,
     Notification,
+    NotifyStatus,
     BankAuthorization,
     OauthBankAuthorization,
     Profile,
@@ -95,6 +96,22 @@ export default class Member extends CoreMember {
     unlinkAccounts(accountIds: Array<string>): Promise<void> {
         return Util.callAsync(this.unlinkAccounts, async() => {
             await this._client.unlinkAccounts(accountIds);
+        });
+    }
+
+    /**
+     * Sends a notification to a user to request a payment.
+     *
+     * @param tokenPayload - requested transfer token
+     * @return status
+     */
+    notifyPaymentRequest(tokenPayload: Object): Promise<NotifyStatus> {
+        return Util.callAsync(this.notifyPaymentRequest, async () => {
+            if (!tokenPayload.refId) {
+                tokenPayload.refId = Util.generateNonce();
+            }
+            const res = await this._client.notifyPaymentRequest(tokenPayload);
+            return res.data.status;
         });
     }
 

--- a/app/src/main/TokenClient.js
+++ b/app/src/main/TokenClient.js
@@ -166,6 +166,7 @@ export class TokenClient extends Core {
      *
      * @param tokenPayload - requested transfer token
      * @return status
+     * @deprecated use Member#notifyPaymentRequest instead
      */
     notifyPaymentRequest(tokenPayload: Object): Promise<NotifyStatus> {
         if (!tokenPayload.refId) {

--- a/app/test/http/AuthHttpClient.spec.js
+++ b/app/test/http/AuthHttpClient.spec.js
@@ -169,3 +169,71 @@ describe('Member misc headers', () => {
             'm:test:member:789');
     });
 });
+
+describe('Member notifyPaymentRequest', () => {
+    it('should send an authenticated POST to the request-transfer path', async () => {
+        const memberId = 'm:test:789';
+        const engine = new MemoryCryptoEngine(memberId);
+        await engine.generateKey('LOW');
+        const member = new Member({
+            env: TEST_ENV,
+            memberId,
+            cryptoEngine: engine,
+            developerKey: devKey,
+        });
+        let captured;
+        // stub both clients, so using the unauthenticated one is caught
+        // rather than escaping to the network
+        for (const client of [member._client, member._unauthenticatedClient]) {
+            client._instance.defaults.adapter = async config => {
+                captured = config;
+                return {
+                    data: {status: 'ACCEPTED'},
+                    status: 200,
+                    statusText: 'OK',
+                    headers: {},
+                    config,
+                };
+            };
+        }
+
+        await member.notifyPaymentRequest({description: 'test', refId: 'ref-1'});
+
+        assert.equal(captured.method, 'post');
+        assert.equal(captured.url, '/request-transfer');
+        assert.deepEqual(JSON.parse(captured.data).tokenPayload.refId, 'ref-1');
+        const authorization = captured.headers.get('Authorization');
+        assert.isOk(authorization, 'request was not authenticated');
+        assert.match(authorization, new RegExp(`member-id=${memberId},`));
+        assert.match(authorization, /signature=[^,]+/);
+    });
+
+    it('should default a missing refId', async () => {
+        const memberId = 'm:test:790';
+        const engine = new MemoryCryptoEngine(memberId);
+        await engine.generateKey('LOW');
+        const member = new Member({
+            env: TEST_ENV,
+            memberId,
+            cryptoEngine: engine,
+            developerKey: devKey,
+        });
+        let captured;
+        for (const client of [member._client, member._unauthenticatedClient]) {
+            client._instance.defaults.adapter = async config => {
+                captured = config;
+                return {
+                    data: {status: 'ACCEPTED'},
+                    status: 200,
+                    statusText: 'OK',
+                    headers: {},
+                    config,
+                };
+            };
+        }
+
+        await member.notifyPaymentRequest({description: 'test'});
+
+        assert.isOk(JSON.parse(captured.data).tokenPayload.refId, 'refId was not defaulted');
+    });
+});


### PR DESCRIPTION
# Description
[PAYENG-461](https://tokenio.atlassian.net/browse/PAYENG-461) — mirrors [sdk-java#612](https://github.com/tokenio/sdk-java/pull/612) in `@token-io/app`: `notifyPaymentRequest` only existed on the unauthenticated client, so this adds it to `Member`/`AuthHttpClient` and deprecates the old two.
Client support only — the gateway is untouched and still fails open, so nothing changes in production. This exists so callers have somewhere to move before the gateway starts requiring auth; that enforcement is a separate change on the same ticket.
Keeping the old methods rather than removing them as #524 did, because #524 had an authenticated twin to point at already and this endpoint had none — removal needs its own major bump once callers have moved.
The specs assert the request really carries member-id and signature, and stub both clients so quietly using the unauthenticated one fails; this repo has no CI, so they were run out-of-band.

# Checklist
- [x] Tests added/updated
- [ ] PII and PAN data redacted/encrypted in logs


[PAYENG-461]: https://tokenio.atlassian.net/browse/PAYENG-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ