### PR TITLE
[TEK-0000] Fail closed when a CSRF-bound callback is parsed without its token

### DIFF
--- a/tpp/package.json
+++ b/tpp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@token-io/tpp",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Token JavaScript TPP SDK",
     "license": "ISC",
     "author": {

--- a/tpp/src/main/Member.js
+++ b/tpp/src/main/Member.js
@@ -299,6 +299,9 @@ export default class Member extends CoreMember {
                 signature: JSON.parse(callback.signature),
             };
 
+            if (params.state.csrfTokenHash && !csrfToken) {
+                throw new Error('Missing CSRF token: the callback state is bound to one');
+            }
             if (csrfToken &&
                 params.state.csrfTokenHash !== Util.hashString(csrfToken)) {
                 throw new Error('Invalid CSRF token');

--- a/tpp/test/sample/TokenRequestUrlSample.spec.js
+++ b/tpp/test/sample/TokenRequestUrlSample.spec.js
@@ -32,4 +32,34 @@ describe('TokenRequestUrl test', () => {
         assert.equal(token.id, callback.tokenId);
         assert.equal('state', callback.innerState);
     });
+
+    it('Should reject a CSRF-bound callback parsed without the CSRF token', async () => {
+        const csrfToken = Util.generateNonce();
+        const state = encodeURIComponent(JSON.stringify({
+            innerState: 'state',
+            csrfTokenHash: Util.hashString(csrfToken),
+        }));
+        const tokenRequestId = Util.generateNonce();
+        const grantor = await TestUtil.createUserMember();
+        const grantee = await CreateMemberSample();
+        const token = await TestUtil.createAccessToken(grantor, await grantee.firstAlias());
+        const signature = await grantor.signTokenRequestState(tokenRequestId, token.id, state);
+        const callbackParams = {
+            tokenId: token.id,
+            state,
+            signature: JSON.stringify(signature),
+        };
+
+        try {
+            await grantee.parseTokenRequestCallbackParams(callbackParams);
+            return Promise.reject('Should fail without the CSRF token');
+        } catch (e) {
+            assert.include(e.message, 'Missing CSRF token');
+            const callback = await grantee
+                .parseTokenRequestCallbackParams(callbackParams, csrfToken);
+            assert.equal(token.id, callback.tokenId);
+            assert.equal('state', callback.innerState);
+            return true;
+        }
+    });
 });


### PR DESCRIPTION
TEK-0000 (placeholder — ticket not yet filed)

- `parseTokenRequestCallbackParams` guarded the CSRF comparison on a truthy `csrfToken` (`tpp/src/main/Member.js:302`), so a callback whose `state` carries a `csrfTokenHash` verified with no session binding at all when the caller omitted the token; it now throws.
- That hash is the only per-session binding the V1 redirect has — the ED25519 signature covers just `token_id` and `state` (`lib-proto` `token.proto:435`) — and our own reference merchant omits the token ([merchant-demo/server/merchant.js#L440](https://github.com/tokenio/merchant-demo/blob/master/server/merchant.js#L440)).
- Non-breaking: the guard fires only where `setCSRFToken` was used at request creation, so integrations that never opted in are untouched. `@token-io/tpp` 3.0.0 → 3.1.0. It does not cover an integration that never set a CSRF token — that needs the always-required variant and merchant comms.
