### PR TITLE
[TEK-194] Normalize aliases locally instead of calling NormalizeAlias

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@token-io/core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@token-io/core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Token JavaScript Core SDK",
   "license": "ISC",
   "author": {

--- a/core/src/Util.js
+++ b/core/src/Util.js
@@ -138,6 +138,30 @@ export class Util {
     }
 
     /**
+     * Normalizes an alias. Mirrors the normalization the backend applies, so no API call
+     * is needed: every alias type is lower cased and trimmed, except EIDAS, whose value is
+     * case sensitive and is only trimmed.
+     *
+     * @param {Object} alias - alias to normalize
+     * @return {Object} a new, normalized alias
+     */
+    static normalizeAlias(alias) {
+        switch (alias.type) {
+        case 'BANK':
+        case 'CUSTOM':
+        case 'DOMAIN':
+        case 'EMAIL':
+        case 'PHONE':
+        case 'USERNAME':
+            return {...alias, value: alias.value.toLowerCase().trim()};
+        case 'EIDAS':
+            return {...alias, value: alias.value.trim()};
+        default:
+            throw new Error('Invalid alias type: ' + alias.type);
+        }
+    }
+
+    /**
      * Support alias hashing
      *
      * @param {Object} alias - alias to be hashed

--- a/core/src/http/HttpClient.js
+++ b/core/src/http/HttpClient.js
@@ -64,14 +64,6 @@ export class HttpClient {
         this._context.miscHeaders = {};
     }
 
-    async normalizeAlias(alias) {
-        const request = {
-            method: 'get',
-            url: `/aliases/normalize/${alias.type}/${alias.value}/${alias.realm || 'token'}`,
-        };
-        return this._instance(request);
-    }
-
     /**
      * Gets a member given an alias.
      *

--- a/core/src/main/Member.js
+++ b/core/src/main/Member.js
@@ -178,8 +178,8 @@ export class Member {
     addAliases(aliases: Array<Alias>): Promise<void> {
         return Util.callAsync(this.addAliases, async () => {
             const member = await this._getMember();
-            const normalized = await Promise.all(aliases.map(alias =>
-                this._normalizeAlias(alias, member.partnerId)));
+            const normalized = aliases.map(alias =>
+                this._normalizeAlias(alias, member.partnerId));
             const prevHash = await this.lastHash();
             await this._client.addAliases(prevHash, normalized);
         });
@@ -543,23 +543,17 @@ export class Member {
         });
     }
 
-    _normalizeAlias(alias: Alias, partnerId: string): Promise<Alias> {
-        return Util.callAsync(this._normalizeAlias, async () => {
-            const normalized =
-                (await this._unauthenticatedClient.normalizeAlias(alias)).data.alias;
+    _normalizeAlias(alias: Alias, partnerId: string): Alias {
+        const normalized = Util.normalizeAlias(alias);
 
-            if (partnerId && partnerId !== 'token') {
-                // Realm must equal member's partner ID if affiliated
-                if (normalized.realm && normalized.realm !== partnerId) {
-                    throw new Error('Alias realm must equal partner ID: ' + partnerId);
-                }
-                normalized.realm = partnerId;
+        if (partnerId && partnerId !== 'token') {
+            // Realm must equal member's partner ID if affiliated
+            if (normalized.realm && normalized.realm !== partnerId) {
+                throw new Error('Alias realm must equal partner ID: ' + partnerId);
             }
-            if (alias.realmId) {
-                normalized.realmId = alias.realmId;
-            }
-            return normalized;
-        });
+            normalized.realm = partnerId;
+        }
+        return normalized;
     }
 }
 

--- a/tpp/test/Util.spec.js
+++ b/tpp/test/Util.spec.js
@@ -32,4 +32,33 @@ describe('Util', () => {
         assert.equal(Util.hashAndSerializeAlias(alias),
             '5cmRKhdQaKFrkso7E4UHyY6AB5yUN2UE6JLfAJCQDZo2');
     });
+
+    it('should lower case and trim the alias value', () => {
+        assert.deepEqual(
+            Util.normalizeAlias({type: 'EMAIL', value: '  Alias@Token.IO '}),
+            {type: 'EMAIL', value: 'alias@token.io'});
+        assert.deepEqual(
+            Util.normalizeAlias({type: 'DOMAIN', value: 'Token.IO'}),
+            {type: 'DOMAIN', value: 'token.io'});
+    });
+
+    it('should only trim an EIDAS alias value, as it is case sensitive', () => {
+        assert.deepEqual(
+            Util.normalizeAlias({type: 'EIDAS', value: ' PSDGB-FCA-AbC123 '}),
+            {type: 'EIDAS', value: 'PSDGB-FCA-AbC123'});
+    });
+
+    it('should keep the realm and realm ID, and leave the input untouched', () => {
+        const alias = {type: 'EMAIL', value: 'Alias@Token.io', realm: 'r', realmId: 'm:1'};
+        assert.deepEqual(
+            Util.normalizeAlias(alias),
+            {type: 'EMAIL', value: 'alias@token.io', realm: 'r', realmId: 'm:1'});
+        assert.equal(alias.value, 'Alias@Token.io');
+    });
+
+    it('should reject an unknown alias type', () => {
+        assert.throws(
+            () => Util.normalizeAlias({type: 'INVALID', value: 'x'}),
+            'Invalid alias type: INVALID');
+    });
 });

--- a/tpp/test/http/AuthHttpClient.spec.js
+++ b/tpp/test/http/AuthHttpClient.spec.js
@@ -197,6 +197,45 @@ describe('Member getMember', () => {
     });
 });
 
+describe('Member addAliases', () => {
+    it('should normalize the alias locally, without calling the API', async () => {
+        const memberId = 'm:test:alias';
+        const engine = new MemoryCryptoEngine(memberId);
+        await engine.generateKey('PRIVILEGED');
+        await engine.generateKey('LOW');
+        const member = new Member({
+            env: TEST_ENV,
+            memberId,
+            cryptoEngine: engine,
+            developerKey: devKey,
+        });
+        const captured = [];
+        // stub both clients, so any call that escapes to the network is caught here instead
+        for (const client of [member._client, member._unauthenticatedClient]) {
+            client._instance.defaults.adapter = async config => {
+                captured.push(config);
+                return {
+                    data: {member: {id: memberId, lastHash: 'h:prev'}},
+                    status: 200,
+                    statusText: 'OK',
+                    headers: {},
+                    config,
+                };
+            };
+        }
+
+        await member.addAliases([{type: 'EMAIL', value: '  Alias@Token.io '}]);
+
+        assert.isNotOk(
+            captured.find(config => config.url.includes('/aliases/normalize')),
+            'alias normalization was sent to the API');
+        const update = captured.find(config => config.url.endsWith('/updates'));
+        assert.isOk(update, 'member update was not sent');
+        const {metadata} = JSON.parse(update.data);
+        assert.equal(metadata[0].addAliasMetadata.alias.value, 'alias@token.io');
+    });
+});
+
 describe('Member misc headers', () => {
     it('should automatically set member-id header', () => {
         const engine = new MemoryCryptoEngine('m:test:member:456');


### PR DESCRIPTION
## Why

`Member.addAliases` called `GET /aliases/normalize` once per alias. That normalization is a lower case and a trim — it does not need a round trip to Token's API.

## What

- Added `Util.normalizeAlias`, mirroring the backend's `AliasHasher.normalize`: lower case + trim for every alias type, trim only for `EIDAS` (case sensitive), throws on an unknown type.
- `Member._normalizeAlias` uses it and is now synchronous; removed `HttpClient.normalizeAlias`.
- `@token-io/core` to 3.0.0 — major, since a method is removed from the exported `HttpClient`. The `app` / `tpp` dependency bumps follow once 3.0.0 is published.

Every other SDK already normalizes locally; sdk-js was the last caller.

## Tests

`Util.spec.js` covers the semantics including `EIDAS` and realm preservation. `AuthHttpClient.spec.js` asserts `addAliases` sends no `/aliases/normalize` request — verified it fails against the old code.

Jira: [TEK-194](https://tokenio.atlassian.net/browse/TEK-194)

[TEK-194]: https://tokenio.atlassian.net/browse/TEK-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ